### PR TITLE
Lexicase selection

### DIFF
--- a/src/clojush.clj
+++ b/src/clojush.clj
@@ -2080,7 +2080,10 @@ normal, or :abnormal otherwise."
                (rest cases))))))
 
 (defn select
-  ([pop] select pop 0 0 0)
+  ([pop]
+    (select pop 1 0 0))
+  ([pop tournament-size]
+    (select pop tournament-size 0 0))
   ([pop tournament-size radius location]
     (if @global-use-lexicase-selection
       (lexicase-selection pop)


### PR DESCRIPTION
Added lexicase parent selection to clojush. You activate it by mapping to true, the pushgp key :use-lexicase-selection
When :use-lexicase-selection is true, the lexicase parent selection becomes the default select function. Also, when enabled, calculation of solution rates is not done because HAH is not utilized. Either HAH or lexicase selection can only be enabled. If lexicase selection is enabled, HAH will never be used. 
