### PR TITLE
Added root mean square error (rmse) as an option for fitness function.

### DIFF
--- a/src/clojush/evaluate.clj
+++ b/src/clojush/evaluate.clj
@@ -3,7 +3,8 @@
         [clojush.pushstate]
         [clojush.random]
         [clojush.globals]
-        [clojush.individual]))
+        [clojush.individual])
+  (:require [clojure.math.numeric-tower :as math]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; evaluate individuals
@@ -11,6 +12,14 @@
 (defn compute-total-error
   [errors]
   (reduce +' errors))
+
+(defn compute-root-mean-square-error
+  [errors]
+  (if @global-use-rmse
+    (math/sqrt (/ (apply +' (map #(* % %)
+                                 errors))
+                  (count errors)))
+    nil))
 
 (defn compute-hah-error
   [errors]
@@ -47,7 +56,8 @@
           te (if (and (number? (:total-error i)) @global-reuse-errors)
                (:total-error i)
                (keep-number-reasonable (compute-total-error e)))
-          he (compute-hah-error e)]
-      (make-individual :program p :errors e :total-error te :hah-error he
+          he (compute-hah-error e)
+          rmse (compute-root-mean-square-error e)]
+      (make-individual :program p :errors e :total-error te :hah-error he :rms-error rmse
                        :history (if maintain-histories (cons te (:history i)) (:history i))
                        :ancestors (:ancestors i)))))

--- a/src/clojush/globals.clj
+++ b/src/clojush/globals.clj
@@ -31,6 +31,7 @@
 (def global-node-selection-tournament-size (atom 2))
 (def global-pop-when-tagging (atom true))
 (def global-reuse-errors (atom true))
+(def global-use-rmse (atom false))
 (def global-use-single-thread (atom false))
 
 ;; Historically-assessed hardness (http://hampshire.edu/lspector/pubs/kleinspector-gptp08-preprint.pdf)

--- a/src/clojush/individual.clj
+++ b/src/clojush/individual.clj
@@ -5,13 +5,14 @@
 ;; Populations are vectors of agents with individuals as their states (along with error and
 ;; history information).
 
-(defrecord individual [program errors total-error hah-error history ancestors])
+(defrecord individual [program errors total-error hah-error rms-error history ancestors])
 
-(defn make-individual [& {:keys [program errors total-error hah-error history ancestors]
+(defn make-individual [& {:keys [program errors total-error hah-error rms-error history ancestors]
                           :or {program nil
                                errors nil
                                total-error nil ;; a non-number is used to indicate no value
                                hah-error nil
+                               rms-error nil
                                history nil
                                ancestors nil}}]
-  (individual. program errors total-error hah-error history ancestors))
+  (individual. program errors total-error hah-error rms-error history ancestors))

--- a/src/clojush/pushgp/parent_selection.clj
+++ b/src/clojush/pushgp/parent_selection.clj
@@ -35,6 +35,9 @@
                      (lrand-int (count pop))
                      (mod (+ location (- (lrand-int (+ 1 (* radius 2))) radius))
                           (count pop))))))
-          err-fn (if @global-use-historically-assessed-hardness :hah-error :total-error)]
+          err-fn (cond
+                   @global-use-historically-assessed-hardness :hah-error
+                   @global-use-rmse :rms-error
+                   true :total-error)]
       (reduce (fn [i1 i2] (if (< (err-fn i1) (err-fn i2)) i1 i2))
               tournament-set))))

--- a/src/clojush/pushgp/pushgp.clj
+++ b/src/clojush/pushgp/pushgp.clj
@@ -35,7 +35,8 @@
              gaussian-mutation-per-number-mutation-probability
              gaussian-mutation-standard-deviation reuse-errors
              problem-specific-report use-single-thread random-seed
-             use-historically-assessed-hardness use-lexicase-selection]
+             use-historically-assessed-hardness use-lexicase-selection
+             use-rmse]
       :or {error-function (fn [p] '(0)) ;; pgm -> list of errors (1 per case)
            error-threshold 0
            population-size 1000
@@ -72,6 +73,7 @@
            random-seed (System/nanoTime)
            use-historically-assessed-hardness false
            use-lexicase-selection false
+           use-rmse false
            }}]
   (binding [*thread-local-random-generator* (java.util.Random. random-seed)]
     ;; set globals from parameters
@@ -86,6 +88,7 @@
     (reset! global-reuse-errors reuse-errors)
     (reset! global-use-historically-assessed-hardness use-historically-assessed-hardness)
     (reset! global-use-lexicase-selection use-lexicase-selection)
+    (reset! global-use-rmse use-rmse)
     (initial-report) ;; Print the inital report
     (print-params 
       (error-function error-threshold population-size max-points max-points-in-initial-program
@@ -98,7 +101,7 @@
                       decimation-tournament-size evalpush-limit evalpush-time-limit node-selection-method 
                       node-selection-tournament-size node-selection-leaf-probability pop-when-tagging 
                       reuse-errors use-single-thread random-seed use-historically-assessed-hardness
-                      use-lexicase-selection))
+                      use-lexicase-selection use-rmse))
     (printf "\nGenerating initial population...\n") (flush)
     (let [pop-agents (vec (doall (for [_ (range population-size)] 
                                    ((if use-single-thread atom agent)

--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -57,6 +57,7 @@
       (printf "\nMean: %.4f" (float (/ (:total-error best)
                                        (count (:errors best)))))(flush)
       (printf "\nHAH-error: %s" (:hah-error best))(flush)
+      (printf "\nRMS-error: %s" (:rms-error best))(flush)
       (printf "\nHistory: %s" (not-lazy (:history best)))(flush)
       (printf "\nSize: %s" (count-points (:program best)))(flush)
       (print "\n--- Population Statistics ---\nAverage total errors in population: ")(flush)


### PR DESCRIPTION
I noticed that the bioavailability paper uses root mean square error (RMSE) of the error values as its fitness function. So, it seemed reasonable to add an option to always be able to use RMSE as the error function without it being explicit in the error function. This adds such an option with the pushgp parameter "use-rmse". When not in use, it shouldn't slow things down or otherwise make any problems any more than any other bypassed if statement.

Lee - if you think this isn't general enough to push to the main branch, let me know and I can just add it to bioavailability.
