### PR TITLE
Added deletion of parentheses pairs to the deletion mutation operator.

### DIFF
--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -73,7 +73,12 @@
                                         true 4))]
                       (if (zero? how-many)
                         prog
-                        (recur (remove-code-at-point prog (lrand-int (count-points prog)))
+                        (recur (let [point-index (lrand-int (count-points prog))
+                                     point (code-at-point prog point-index)]
+                                 (if (and (seq? point)
+                                          (< (lrand) 0.2))
+                                   (remove-parens-at-point prog point-index)
+                                   (remove-code-at-point prog point-index)))
                                (dec how-many))))]
     (make-individual :program new-program :history (:history ind)
                      :ancestors (if maintain-ancestors

--- a/src/clojush/util.clj
+++ b/src/clojush/util.clj
@@ -81,7 +81,38 @@
                    (= 1 (count (zip/node z))))
             (zip/root z) ;(zip/remove z))
             (recur (zip/next z) (dec i))))))))
-  
+
+(defn remove-parens-at-point
+  "Returns a copy of tree with the parens of the subtree formerly indexed by
+   point-index (in a depth-first traversal) removed. This
+   only works if that subtree is a sequence, otherwise this
+   just returns the tree. Also, can't remove from index 0,
+   since you can't remove the outmost parens."
+  [tree point-index]
+  (let [index (mod (math/abs point-index) (count-points tree))
+        zipper (zip/seq-zip tree)]
+    (if (zero? index)
+      tree ;; can't remove entire tree's parens
+      (let [z-found (loop [z zipper i index]
+                      (if (zero? i)
+                        z
+                        (if (and (= i 1) ;; can't remove only item from list
+                                 (seq? (zip/node z))
+                                 (= 1 (count (zip/node z))))
+                          (zip/root z) ;(zip/remove z))
+                          (recur (zip/next z) (dec i)))))]
+        (if (not (seq? (zip/node z-found))) ;can't un-paren non-seq things
+          (zip/root z-found)
+          (if (empty? (zip/children z-found)) ;seq is empty, just remove it
+            (zip/root (zip/remove z-found))
+            (let [children (zip/children z-found)]
+              (loop [ch (butlast children)
+                     z (zip/replace z-found (last children))]
+                (if (empty? ch)
+                  (zip/root z)
+                  (recur (rest ch)
+                         (zip/insert-left z (first ch))))))))))))
+
 (defn truncate
   "Returns a truncated integer version of n."
   [n]


### PR DESCRIPTION
Someone (probably Lee) should check this code before merging, particularly the new util function remove-parens-at-point, to make sure it's sound. The methods used there for removing some parens are a bit convoluted, and maybe could be improved with better understanding of zippers.
