### PR TITLE
Added options print-errors and print-history to pushgp, which turn off

### DIFF
--- a/src/clojush/pushgp/pushgp.clj
+++ b/src/clojush/pushgp/pushgp.clj
@@ -66,7 +66,9 @@
                        :ultra-probability 0.0
                        :ultra-alternation-rate 0.1
                        :ultra-alignment-deviation 1
-                       :ultra-mutation-rate 0.1)))
+                       :ultra-mutation-rate 0.1
+                       :print-errors true
+                       :print-history true)))
 
 (defn load-push-argmap
   [argmap]
@@ -135,18 +137,18 @@
   [pop-agents generation {:keys [error-function report-simplifications print-csv-logs print-json-logs
                                  csv-log-filename json-log-filename max-generations
                                  log-fitnesses-for-all-cases json-log-program-strings
+                                 print-errors print-history
                                  problem-specific-report error-threshold]}]
   (let [best (report (vec (doall (map deref pop-agents))) generation error-function 
                      report-simplifications print-csv-logs print-json-logs
                      csv-log-filename json-log-filename
                      log-fitnesses-for-all-cases json-log-program-strings
+                     print-errors print-history
                      problem-specific-report)]
     (cond (<= (:total-error best) error-threshold) best
           (>= generation max-generations) :failure
           :else :continue)))
           
-
-
 (defn produce-new-offspring
   [pop-agents child-agents rand-gens
    {:keys [decimation-ratio population-size decimation-tournament-size trivial-geography-radius

--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -119,14 +119,17 @@
    individual of the generation."
   ([population generation error-function report-simplifications
     print-csv-logs print-json-logs csv-log-filename json-log-filename
-    log-fitnesses-for-all-cases json-log-program-strings]
+    log-fitnesses-for-all-cases json-log-program-strings print-errors
+    print-history]
     (report population generation error-function report-simplifications
             print-csv-logs print-json-logs csv-log-filename json-log-filename
             log-fitnesses-for-all-cases json-log-program-strings
+            print-errors print-history
             default-problem-specific-report))
   ([population generation error-function report-simplifications
     print-csv-logs print-json-logs csv-log-filename json-log-filename
-    log-fitnesses-for-all-cases json-log-program-strings problem-specific-report]
+    log-fitnesses-for-all-cases json-log-program-strings print-errors
+    print-history problem-specific-report]
     (printf "\n\n;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;")(flush)
     ;(println (map :total-error population))(flush) ;***
     (printf "\n;; -*- Report at generation %s" generation)(flush)
@@ -140,13 +143,13 @@
       (flush)
       (printf "\nCosmos Data: %s" (let [quants (config/quantiles (count population))]
                                     (zipmap quants (map #(:total-error (nth (sort-by :total-error population) %)) quants))))
-      (printf "\nErrors: %s" (not-lazy (:errors best)))(flush)
+      (when print-errors (printf "\nErrors: %s" (not-lazy (:errors best))))(flush)
       (printf "\nTotal: %s" (:total-error best))(flush)
       (printf "\nMean: %.4f" (float (/ (:total-error best)
                                        (count (:errors best)))))(flush)
       (printf "\nHAH-error: %s" (:hah-error best))(flush)
       (printf "\nRMS-error: %s" (:rms-error best))(flush)
-      (printf "\nHistory: %s" (not-lazy (:history best)))(flush)
+      (when print-history (printf "\nHistory: %s" (not-lazy (:history best))))(flush)
       (printf "\nSize: %s" (count-points (:program best)))(flush)
       (print "\n--- Population Statistics ---\nAverage total errors in population: ")(flush)
       (print (*' 1.0 (/ (reduce +' (map :total-error sorted)) (count population))))(flush)


### PR DESCRIPTION
printing of those things if false.

This adds pushgp arguments for not printing errors and histories. Sometimes they're just too big!
