### PR TITLE
Print stack trace on error

### DIFF
--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -321,7 +321,7 @@ that performs a comparison of the type, as in [:integer 'integer_eq]."
             (> (count result) 10000)) ;; runaway growth
       result
       (if (< (lrand) alternation-rate)
-        (recur (max 0 (+ i (Math/round (* alignment-deviation (gaussian-noise-factor)))))
+        (recur (max 0 (+' i (Math/round (*' alignment-deviation (gaussian-noise-factor)))))
                (not use-s1)
                result)
         (recur (inc i)

--- a/src/clojush/pushgp/pushgp.clj
+++ b/src/clojush/pushgp/pushgp.clj
@@ -83,7 +83,10 @@
 
 (defn make-agents-and-rng [{:keys [initial-population use-single-thread population-size
                                    max-points-in-initial-program atom-generators random-seed]}]
-  (let [agent-error-handler (fn [agnt except] (println except) (.printStackTrace except) (System/exit 0))]
+  (let [agent-error-handler (fn [agnt except]
+                              (.printStackTrace except System/out)
+                              (.printStackTrace except)
+                              (System/exit 0))]
     {:pop-agents (if initial-population
                    (->> (read-string (slurp (str "data/" initial-population)))
                         (map #(if use-single-thread (atom %) (agent %)))


### PR DESCRIPTION
Fixes ULTRA arithmetic errors. Also, prints stack traces to both stdout and stderr when an agent has an exception.
