### PR TITLE
Made random code inserted with ULTRA mutation come from random-code function.

### DIFF
--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -333,8 +333,7 @@ that performs a comparison of the type, as in [:integer 'integer_eq]."
 (defn linearly-mutate
   [open-close-sequence mutation-rate atom-generators]
   (map #(if (< (lrand) mutation-rate)
-          (let [element (lrand-nth (concat atom-generators [:open :close ()]))]
-            (if (fn? element) (element) element))
+          (random-code 1 (concat atom-generators [:open :close ()]))
           %)
        open-close-sequence))
 


### PR DESCRIPTION
This code just makes it so that ULTRA mutation uses random-code instead of sampling directly from the atom generators. This is cleaner conceptually, and fixes an issue I was having with atom generators + tags.
