### PR TITLE
Provide option to return best simplified individual on failure

### DIFF
--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -277,9 +277,9 @@
     (when print-json-logs (json-print population generation json-log-filename
                                       log-fitnesses-for-all-cases json-log-program-strings))
     (cond (or (<= (:total-error best) error-threshold)
-              (:success best)) best
-          (>= generation max-generations) :failure
-          :else :continue)))
+              (:success best)) [:success best]
+          (>= generation max-generations) [:failure best]
+          :else [:continue best])))
 
 (defn initial-report
   "Prints the initial report of a PushGP run."


### PR DESCRIPTION
I want to be able to limit my runs to set `max-generations` to a small number and still return the best function and error found so far, even if PushGP ends before the error threshold has been reached. I have added a config called `return-simplified-on-failure`, which, if true, will return the best individual, autosimplified, even if it has not succeeded. By default, it is set to false, and will maintain current behavior so this will not require any changes by those who use the library currently.
