### PR TITLE
Fixed bug where normalized error was used to compare to threshold

### DIFF
--- a/src/clojush/individual.clj
+++ b/src/clojush/individual.clj
@@ -1,23 +1,23 @@
-(ns clojush.individual
-  (:require [clojure.string :as s]))
+(ns clojush.individual)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Individuals are records.
 ;; Populations are vectors of agents with individuals as their states (along with error and
 ;; history information).
 
-(defrecord individual [genome program errors total-error weighted-error history ancestors parent])
+(defrecord individual [genome program errors total-error normalized-error weighted-error history ancestors parent])
 
-(defn make-individual [& {:keys [genome program errors total-error weighted-error history ancestors parent]
+(defn make-individual [& {:keys [genome program errors total-error normalized-error weighted-error history ancestors parent]
                           :or {genome nil
                                program nil
                                errors nil
                                total-error nil ;; a non-number is used to indicate no value
+                               normalized-error nil
                                weighted-error nil
                                history nil
                                ancestors nil
                                parent nil}}]
-  (individual. genome program errors total-error weighted-error history ancestors parent))
+  (individual. genome program errors total-error normalized-error weighted-error history ancestors parent))
 
 (defn printable [thing]
   (letfn [(unlazy [[head & tail]]
@@ -29,6 +29,6 @@
 
 (defn individual-string [i]
   (cons 'individual.
-        (let [k '(:genome :program :errors :total-error :weighted-error :history :ancestors :parent)]
+        (let [k '(:genome :program :errors :total-error :normalized-error :weighted-error :history :ancestors :parent)]
           (interleave k  (map #(printable (get i %)) k)))))
 

--- a/src/clojush/pushgp/parent_selection.clj
+++ b/src/clojush/pushgp/parent_selection.clj
@@ -110,19 +110,13 @@
    error across each test case."
   [ind summed-reward-on-test-cases]
   (let [ifs-reward (apply +' (map #(if (zero? %2) 1.0 (/ %1 %2))
-                                  (map #(- 1.0 %) (:errors ind)) ; Should be dividing REWARD by summed (not ERRORS)
+                                  (map #(- 1.0 %) (:errors ind))
                                   summed-reward-on-test-cases))
         ifs-er (cond
                  (< 1e20 ifs-reward) 0.0
                  (zero? ifs-reward) 1e20
                  (< 1e20 (/ 1.0 ifs-reward)) 1e20
                  :else (/ 1.0 ifs-reward))]
-    ;(println "\n\n\n")
-    ;(println "IFS Fitness rewards:")
-    ; (doseq [[e s i] (map vector (:errors ind) summed-reward-on-test-cases (range))]
-    ; (println (format "T%2d | Error (e): %.4f | 1-e: %.5f | s: %8.4f | (1-e)/s: %.4f" i e (- 1.0 e) s (/ (- 1.0 e) s))))
-    ;(println (format "IFS Reward: %7.4f" ifs-reward))
-    ;(println (format "IFS Error: %7.4f" ifs-er))
     (assoc ind :weighted-error ifs-er)))
 
 (defn calculate-implicit-fitness-sharing

--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -234,7 +234,7 @@
            print-errors print-history print-cosmos-data print-timings
            problem-specific-report total-error-method
            parent-selection print-homology-data
-           print-error-frequencies-by-case
+           print-error-frequencies-by-case normalization
            ;; The following are for CSV or JSON logs
            print-csv-logs print-json-logs csv-log-filename json-log-filename
            log-fitnesses-for-all-cases json-log-program-strings
@@ -298,6 +298,8 @@
     (println "Total:" (:total-error best))
     (println "Mean:" (float (/ (:total-error best)
                                (count (:errors best)))))
+    (when (not= normalization :none)
+      (println "Normalized error:" (:normalized-error best)))
     (case total-error-method
       :hah (println "HAH-error:" (:weighted-error best))
       :rmse (println "RMS-error:" (:weighted-error best))


### PR DESCRIPTION
I realized that if normalization was being used, the normalized errors were being compared to the threshold value to determine if a successful program was found. This is not the desired behavior, since the threshold is not normalized. This patch fixes this by always storing the non-normalized error in an individual's :total-error, and using a new :normalized-error to store and print the normalized total error.
