### PR TITLE
Fix to permit :input items to be code literals (pushed to :exec).

### DIFF
--- a/src/clojush/instructions/input_output.clj
+++ b/src/clojush/instructions/input_output.clj
@@ -51,7 +51,7 @@
 (defn handle-input-instruction
   "Allows Push to handle inN instructions, e.g. in2, using things from the input
    stack. We can tell whether a particular inN instruction is valid if N-1
-   values are on the input stack."
+   values are on the input stack. Recognizes vectors, simple literals and quoted code."
   [instr state]
   (let [n (Integer/parseInt (second (first (re-seq #"in(\d+)" (name instr)))))]
     (if (or (> n (count (:input state)))
@@ -59,6 +59,7 @@
       (throw (Exception. (str "Undefined instruction: " (pr-str instr) "\nNOTE: Likely not same number of items on input stack as input instructions.")))
       (let [item (stack-ref :input (dec n) state)
             literal-type (recognize-literal item)]
-        (if (and (vector? item) (= [] item))
-          (push-item [] :vector_integer (push-item [] :vector_float (push-item [] :vector_string (push-item [] :vector_boolean state))))
-          (push-item item literal-type state))))))
+        (cond
+          (and (vector? item) (= [] item)) (push-item [] :vector_integer (push-item [] :vector_float (push-item [] :vector_string (push-item [] :vector_boolean state))))
+          (seq? item) (push-item item :exec state)
+          :else (push-item item literal-type state))))))


### PR DESCRIPTION
I've exercised this code as well as I'm able, and it doesn't seem to break anything else in the core library. I don't _imagine_ it could break anything in the examples or other problems either: the only effect is to permit items on the `:input` stack that aren't recognized as `vector` literals to be pushed to the `:exec` stack. In other words, it permits `:code` inputs and arguments.

(code patch via @thelmuth)