### PR TITLE
Convenience function push-state-from-stacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ lib/
 /bin
 *.csv
 *.json
+.lein-failures

--- a/project.clj
+++ b/project.clj
@@ -13,8 +13,8 @@
                  [clojure-csv "2.0.0-alpha2"]
                  [org.clojure/data.json "0.1.3"]
                  [clj-random "0.1.7"]]
-  :dev-dependencies [[lein-ccw "1.2.0"]
-                     [midje "1.6.3"]]
+  :dev-dependencies [[lein-ccw "1.2.0"]]
+  :profiles {:dev {:dependencies [[midje "1.6.3"]]}}
   ;;;;;;;;;; jvm settings for high performance, using most of the machine's RAM
 ;  :jvm-opts ~(let [mem-to-use
 ;                   (long (* (.getTotalPhysicalMemorySize

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
                  [clojure-csv "2.0.0-alpha2"]
                  [org.clojure/data.json "0.1.3"]
                  [clj-random "0.1.7"]]
-  :dev-dependencies [[lein-ccw "1.2.0"]]
+  :dev-dependencies [[lein-ccw "1.2.0"]
+                     [midje "1.6.3"]]
   ;;;;;;;;;; jvm settings for high performance, using most of the machine's RAM
 ;  :jvm-opts ~(let [mem-to-use
 ;                   (long (* (.getTotalPhysicalMemorySize

--- a/src/clojush/pushstate.clj
+++ b/src/clojush/pushstate.clj
@@ -140,7 +140,7 @@
                @instruction-table)))
 
 
-(defn push-state-now!
+(defn push-state-from-stacks
   "Takes a map of stack names and entire stack states, and returns a new push-state
    with those stacks set."
   [& {:as stack-assignments}]

--- a/src/clojush/pushstate.clj
+++ b/src/clojush/pushstate.clj
@@ -138,3 +138,14 @@
                  (and (:stack-types (meta instr-fn))
                       (clojure.set/subset? (set (:stack-types (meta instr-fn))) (set types-list))))
                @instruction-table)))
+
+
+(defn push-state-now!
+  "Takes a map of stack names and entire stack states, and returns a new push-state
+   with those stacks set."
+  [& {:as stack-assignments}]
+  (let [tabula-rasa (make-push-state)]
+    (reduce-kv
+      (fn [my-map next-key next-value] (assoc my-map next-key next-value))
+      tabula-rasa
+      stack-assignments)))

--- a/src/clojush/pushstate.clj
+++ b/src/clojush/pushstate.clj
@@ -144,8 +144,5 @@
   "Takes a map of stack names and entire stack states, and returns a new push-state
    with those stacks set."
   [& {:as stack-assignments}]
-  (let [tabula-rasa (make-push-state)]
-    (reduce-kv
-      (fn [my-map next-key next-value] (assoc my-map next-key next-value))
-      tabula-rasa
-      stack-assignments)))
+    (merge (make-push-state) stack-assignments)
+    )

--- a/test/clojush/midje/interpreter/literal_handling.clj
+++ b/test/clojush/midje/interpreter/literal_handling.clj
@@ -1,0 +1,21 @@
+; To run these tests with autotest use:
+;
+;    lein midje :autotest test
+;
+; This runs everything in the test sub-directory but
+; _doesn't_ run all the stuff in src, which midje tries
+; to run by default, which breaks the world.
+
+(ns clojush.midje.interpreter.literal-handling
+  (:use clojure.test
+        midje.sweet
+        clojush.interpreter
+        clojush.pushstate))
+
+(fact "Evaluating a null instruction returns the same state"
+  (execute-instruction nil :test-state) => :test-state)
+
+(fact "Evaluating an integer constant as an instruction adds that value to the integer stack"
+      (let [test-state (make-push-state)
+            value 8]
+        (:integer (execute-instruction value (make-push-state))) => (list value)))

--- a/test/clojush/midje/pushstate/convenience_functions.clj
+++ b/test/clojush/midje/pushstate/convenience_functions.clj
@@ -29,6 +29,11 @@
     (just [1 2 3] [4 5 6])
   )
 
+(fact "passing in weird keys just drops them into the pushstate"
+  (:foo (push-state-now! :foo '(:a :b :c))) => (just :a :b :c) ;; a victimless crime?
+  )
+
 (fact "the result of push-state-now! can be used to run code and stuff"
   (:integer (run-push '(integer_add integer_add) (push-state-now! :integer '(1 2 3 4)))) => (just 6 4) 
   )
+

--- a/test/clojush/midje/pushstate/convenience_functions.clj
+++ b/test/clojush/midje/pushstate/convenience_functions.clj
@@ -13,36 +13,36 @@
         midje.sweet
         ))
 
-(fact "push-state-now! creates a push-state with all available stacks"
-  (keys (push-state-now!)) => (just clojush.globals/push-types :in-any-order)
+(fact "push-state-from-stacks creates a push-state with all available stacks"
+  (keys (push-state-from-stacks)) => (just clojush.globals/push-types :in-any-order)
   )
 
-(fact "push-state-now! creates a empty stacks if none are passed in"
-  (concat (vals (push-state-now!))) => (has every? nil?)
+(fact "push-state-from-stacks creates a empty stacks if none are passed in"
+  (concat (vals (push-state-from-stacks))) => (has every? nil?)
   )
 
-(facts "push-state-now! sets a named stack to the values passed in as arguments"
-  (:integer (push-state-now! :integer '(1 2 3))) => (just 1 2 3)
-  (:boolean (push-state-now! :boolean '(false true))) => (just false true )
-  (:code (push-state-now! :code '( 122 false integer_add))) => (contains   #{ 122 false 'integer_add})
-  (:vector_integer (push-state-now! :vector_integer '([1 2 3] [4 5 6]))) =>
+(facts "push-state-from-stacks sets a named stack to the values passed in as arguments"
+  (:integer (push-state-from-stacks :integer '(1 2 3))) => (just 1 2 3)
+  (:boolean (push-state-from-stacks :boolean '(false true))) => (just false true )
+  (:code (push-state-from-stacks :code '( 122 false integer_add))) => (contains   #{ 122 false 'integer_add})
+  (:vector_integer (push-state-from-stacks :vector_integer '([1 2 3] [4 5 6]))) =>
     (just [1 2 3] [4 5 6])
   )
 
 
-(def big-state (push-state-now! :integer '(1 2) :boolean '(false) :char '(\f \w \i \w) :rational '(3/4 111/9)))
+(def big-state (push-state-from-stacks :integer '(1 2) :boolean '(false) :char '(\f \w \i \w) :rational '(3/4 111/9)))
 
-(facts "push-state-now! works for multiple stacks"
+(facts "push-state-from-stacks works for multiple stacks"
   (:integer big-state) => (just 1 2)
   (:boolean big-state) => (just false)
   (:char big-state) => (just \f \w \i \w)
   (:rational big-state) => (just 3/4 111/9))
 
 (fact "passing in weird keys just drops them into the pushstate"
-  (:foo (push-state-now! :foo '(:a :b :c))) => (just :a :b :c) ;; a victimless crime?
+  (:foo (push-state-from-stacks :foo '(:a :b :c))) => (just :a :b :c) ;; a victimless crime?
   )
 
-(fact "the result of push-state-now! can be used to run code and stuff"
-  (:integer (run-push '(integer_add integer_add) (push-state-now! :integer '(1 2 3 4)))) => (just 6 4) 
+(fact "the result of push-state-from-stacks can be used to run code and stuff"
+  (:integer (run-push '(integer_add integer_add) (push-state-from-stacks :integer '(1 2 3 4)))) => (just 6 4) 
   )
 

--- a/test/clojush/midje/pushstate/convenience_functions.clj
+++ b/test/clojush/midje/pushstate/convenience_functions.clj
@@ -12,7 +12,7 @@
         clojure.test
         midje.sweet
         ))
-
+   
 (fact "push-state-from-stacks creates a push-state with all available stacks"
   (keys (push-state-from-stacks)) => (just clojush.globals/push-types :in-any-order)
   )
@@ -30,6 +30,11 @@
   )
 
 
+(facts "the unspecified stacks are still empty"
+  (:foo (push-state-from-stacks :foo '(:some :webgl :commands :here))) => (just :some :webgl :commands :here)
+  (:integer (push-state-from-stacks :foo '(:some :webgl :commands :here))) => nil
+  )
+
 (def big-state (push-state-from-stacks :integer '(1 2) :boolean '(false) :char '(\f \w \i \w) :rational '(3/4 111/9)))
 
 (facts "push-state-from-stacks works for multiple stacks"
@@ -44,5 +49,15 @@
 
 (fact "the result of push-state-from-stacks can be used to run code and stuff"
   (:integer (run-push '(integer_add integer_add) (push-state-from-stacks :integer '(1 2 3 4)))) => (just 6 4) 
+  )
+
+
+;; if I want to merge whole new stacks into a pre-existing push-state,
+;; I just want to make sure there is a simple way of doing that...
+
+(def test-state (push-state-from-stacks :integer '(1 2)))
+
+(fact "I don't need to write a special merge-push-state to overwrite the stack in a push-state"
+  (:integer (merge test-state {:integer '(7 7 7)})) => (just 7 7 7)
   )
 

--- a/test/clojush/midje/pushstate/convenience_functions.clj
+++ b/test/clojush/midje/pushstate/convenience_functions.clj
@@ -1,0 +1,34 @@
+; To run these tests with autotest use:
+;
+;    lein midje :autotest test
+;
+; This runs everything in the test sub-directory but
+; _doesn't_ run all the stuff in src, which midje tries
+; to run by default, which breaks the world.
+
+(ns clojush.midje.pushstate.convenience-functions
+  (:use clojush.pushgp.pushgp
+        [clojush pushstate interpreter random util]
+        clojure.test
+        midje.sweet
+        ))
+
+(fact "push-state-now! creates a push-state with all available stacks"
+  (keys (push-state-now!)) => (just clojush.globals/push-types :in-any-order)
+  )
+
+(fact "push-state-now! creates a empty stacks if none are passed in"
+  (concat (vals (push-state-now!))) => (has every? nil?)
+  )
+
+(facts "push-state-now! sets a named stack to the values passed in as arguments"
+  (:integer (push-state-now! :integer '(1 2 3))) => (just 1 2 3)
+  (:boolean (push-state-now! :boolean '(false true))) => (just false true )
+  (:code (push-state-now! :code '( 122 false integer_add))) => (contains   #{ 122 false 'integer_add})
+  (:vector_integer (push-state-now! :vector_integer '([1 2 3] [4 5 6]))) =>
+    (just [1 2 3] [4 5 6])
+  )
+
+(fact "the result of push-state-now! can be used to run code and stuff"
+  (:integer (run-push '(integer_add integer_add) (push-state-now! :integer '(1 2 3 4)))) => (just 6 4) 
+  )

--- a/test/clojush/midje/pushstate/convenience_functions.clj
+++ b/test/clojush/midje/pushstate/convenience_functions.clj
@@ -29,6 +29,15 @@
     (just [1 2 3] [4 5 6])
   )
 
+
+(def big-state (push-state-now! :integer '(1 2) :boolean '(false) :char '(\f \w \i \w) :rational '(3/4 111/9)))
+
+(facts "push-state-now! works for multiple stacks"
+  (:integer big-state) => (just 1 2)
+  (:boolean big-state) => (just false)
+  (:char big-state) => (just \f \w \i \w)
+  (:rational big-state) => (just 3/4 111/9))
+
 (fact "passing in weird keys just drops them into the pushstate"
   (:foo (push-state-now! :foo '(:a :b :c))) => (just :a :b :c) ;; a victimless crime?
   )

--- a/test/clojush/test/clojush_tests.clj
+++ b/test/clojush/test/clojush_tests.clj
@@ -1,562 +1,562 @@
-;; This is a file of commented-out informal tests (without outputs...) 
-;; of functions in coljush.clj.
-
-(ns clojush.test.clojush_tests
-  (:use [clojush.clojush]
-        [clojush.globals]
-        [clojush.random]
-        [clojush.util]
-        [clojush.pushstate]))
-    
-;(in-ns 'clojush)
-
-;(println (random-element '(a b c d e)))
-;(println (shuffle '(a b c d e)))
-;(println (decompose 20 6))
-;(println (shuffle (decompose 20 6)))
-;(println (random-code-with-size 20 '(1 2 3)))
-;(println (random-code-with-size 20 (list 3.14 'squid)))
-;(println (random-code-with-size 20 (list 3.14 'squid (fn [] (rand-int 100)))))
-;(println (random-code 100 (list 3.14 'squid (fn [] (rand-int 100)))))
-
-#_(time (def p
-	   (for [i (range 1000)]
-	     (random-code 100 (list 'a 1)))))
-
-;(time (reduce + (map count (map ensure-list p))))
-	
-;(println (count-points '((this) program (contains (9 points))))) 
-
-;(time (println (reduce + (map count-points p))))
-
-#_(time (reduce + (for [i (range 100)]
-		  (let [lst (for [j (range 1000)] j)]
-		    (first (shuffle lst))))))
-
-;(println (keep-number-reasonable 10E100))
-;(println (keep-number-reasonable -312987231987329187329187321987231987))
-;(println (count-points '((this) program (contains (9 points)))))
-
-;(dotimes [i 10] (println (code-at-point '(a (b c) d) i)))
-;(println '---)
-;(dotimes [i 10] (println (insert-code-at-point '(a (b c) d) i 'x)))
-;(println '---)
-;(dotimes [i 10] (println (remove-code-at-point '(a (b c) d) i)))
-;(println '---)
-;(dotimes [i 10] (println (remove-code-at-point '(a (b c (e)) d) i)))
-;(println '---)
-;(dotimes [i 10] (println (remove-code-at-point '(a (b c (e f)) d) i)))
-
-;(println (make-push-state))
-
-;(register-instruction 'foo)
-;(register-instruction 'bar)
-;(println registered-instructions)
-
-;(println (macroexpand-1 '(define-registered schmoo (fn [] (println 'hello)))))
-
-;(define-registered schmoo (fn [] (println 'hello)))
-
-;(println registered-instructions)
-;(println instruction-table)
-;(schmoo)
-
-;(println (get-stack :integer (make-push-state)))
-
-;(println (state-pretty-print (make-push-state)))
-
-;(get-stack 'integer (make-schush-state))    
-
-#_(let [s (make-push-state)]
-  (println (push-item 'froggy :code s)))
-
-;(println (top-item :code (push-item 'froggy :code (make-push-state))))
-
-;(println (top-item :integer (make-push-state)))
-
-#_(println (stack-ref :integer 
-		    1 
-		    (push-item 2 
-			  :integer
-			  (push-item 1 
-				:integer
-				(push-item 0
-				      :integer
-				      (make-push-state))))))
-
-#_(loop [n 0
-       state (make-push-state)]
-  (if (> n 4)
-    (do (println state)
-	(println (pop-item :integer state)))
-    (recur (inc n) 
-	   (push-item n :integer state))))
-
-;(define-registered integer.schmoo (fn [] 0))
-;(define-registered float.schmoo (fn [] 0))
-;(println (registered-for-type :integer))
-
-;(println ((popper :integer) (push-item 2 :integer (push-item 3 :integer (make-push-state)))))
-
-;(println (->> (make-push-state) (push-item 23 :integer) (push-item 100 :integer) (integer_pop)))
-
-;(println (->> (make-push-state) (push-item 23 :integer) (integer_dup)))
-
-;(println (->> (make-push-state) (push-item 1 :integer) (push-item 2 :integer)))
-;(println (->> (make-push-state) (push-item 1 :integer) (push-item 2 :integer) (integer_swap)))
-;(println (->> (make-push-state) (push-item 1 :integer) (integer_swap)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item 'b :code)
-	      (push-item 'c :code)
-	      (code_rot)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item 'b :code)
-	      (push-item 'c :code)
-	      (code_flush)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item 'b :code)
-	      (code_eq)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item 'a :code)
-	      (code_eq)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (code_eq)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item 'b :code)
-	      (code_stackdepth)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item 'b :code)
-	      (push-item 'c :code)
-	      (push-item 'd :code)
-	      (push-item 2 :integer)
-	      (code_yank)))
-
-#_(println (->> (make-push-state)
-	      (push-item 101 :integer)
-	      (push-item 102 :integer)
-	      (push-item 103 :integer)
-	      (push-item 104 :integer)
-	      (push-item 2 :integer)
-	      (integer_yank)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item 'b :code)
-	      (push-item 'c :code)
-	      (push-item 'd :code)
-	      (push-item 2 :integer)
-	      (code_yankdup)))
-
-#_(println (->> (make-push-state)
-	      (push-item 101 :integer)
-	      (push-item 102 :integer)
-	      (push-item 103 :integer)
-	      (push-item 104 :integer)
-	      (push-item 2 :integer)
-	      (integer_yankdup)))
-
-;(println (run-push '(1 2 integer_dup) (make-push-state) true))
-
-;(println (run-push '(1 2 integer_add) (make-push-state)))
-;(println (run-push '(1 integer_add) (make-push-state)))
-
-;(println (run-push '(100 1 integer_sub) (make-push-state)))
-
-;(println (run-push '(10.0 5.0 float_mult) (make-push-state)))
-
-;(println (run-push '(10.0 6.0 float_div) (make-push-state)))
-;(println (run-push '(-10.0 6.0 float_div) (make-push-state)))
-;(println (run-push '(10 6 integer_div) (make-push-state)))
-;(println (run-push '(-10 6 integer_div) (make-push-state)))
-;(println (run-push '(10.0 0.0 float_div) (make-push-state)))
-;(println (run-push '(10 0 integer_div) (make-push-state)))
-
-;(println (run-push '((10.0 (5.0 float_mult))) (make-push-state)))
-
-;(println (run-push '(10.0 6.0 float_mod) (make-push-state)))
-;(println (run-push '(-10.0 6.0 float_mod) (make-push-state)))
-;(println (run-push '(10 6 integer_mod) (make-push-state)))
-;(println (run-push '(-10 6 integer_mod) (make-push-state)))
-;(println (run-push '(10.0 0.0 float_mod) (make-push-state)))
-;(println (run-push '(10 0 integer_mod) (make-push-state)))
-
-;(println (run-push '(10.0 11.0 float_lt) (make-push-state)))
-;(println (run-push '(10.0 1.0 float_lt) (make-push-state)))
-;(println (run-push '(10.0 11.0 float_gt) (make-push-state)))
-;(println (run-push '(10.0 1.0 float_gt) (make-push-state)))
-
-;(println (run-push '(false integer_fromboolean) (make-push-state)))
-;(println (run-push '(true integer_fromboolean) (make-push-state)))
-;(println (run-push '(integer_fromboolean) (make-push-state)))
-
-;(println (run-push '(false float_fromboolean) (make-push-state)))
-;(println (run-push '(true float_fromboolean) (make-push-state)))
-;(println (run-push '(float_fromboolean) (make-push-state)))
-
-;(println (run-push '(3.14 integer_fromfloat) (make-push-state)))
-;(println (run-push '(3 float_frominteger) (make-push-state)))
-
-;(println (run-push '(1 2 integer_min) (make-push-state)))
-;(println (run-push '(2 1 integer_min) (make-push-state)))
-;(println (run-push '(1.0 2.0 float_min) (make-push-state)))
-;(println (run-push '(2.0 1.0 float_min) (make-push-state)))
-
-;(println (run-push '(1 2 integer_max) (make-push-state)))
-;(println (run-push '(2 1 integer_max) (make-push-state)))
-;(println (run-push '(1.0 2.0 float_max) (make-push-state)))
-;(println (run-push '(2.0 1.0 float_max) (make-push-state)))
-
-;(println (run-push '(3.141592 float_sin) (make-push-state)))
-;(println (run-push '(3.141592 float_cos) (make-push-state)))
-;(println (run-push '(3.141592 float_tan) (make-push-state)))
-
-;(println (run-push '(true false boolean_and) (make-push-state)))
-;(println (run-push '(true true boolean_and) (make-push-state)))
-;(println (run-push '(true boolean_and) (make-push-state)))
-;(println (run-push '(true false boolean_or) (make-push-state)))
-;(println (run-push '(false false boolean_or) (make-push-state)))
-;(println (run-push '(true boolean_or) (make-push-state)))
-;(println (run-push '(true boolean_not) (make-push-state)))
-
-;(println (run-push '(0.0 boolean_fromfloat) (make-push-state)))
-;(println (run-push '(10.0 boolean_fromfloat) (make-push-state)))
-;(println (run-push '(0 boolean_frominteger) (make-push-state)))
-;(println (run-push '(10 boolean_frominteger) (make-push-state)))
-
-
-
-;(dotimes [_ 100]
-#_(println (let [c (random-code 100 (concat registered-instructions 
-					    (list (fn [] (- (rand 2) 1)) 
-					       (fn [] (- (rand-int 20) 10)))))]
-	   (println c)
-	   (run-push c
-		     (make-push-state)
-		     true
-		     )))
-;)
-
-
-;(defn new-pgm 
-;  []
-;  (random-code 100 (concat registered-instructions
-;                           (list (fn [] (- (rand 2) 1))
-;                                 (fn [] (- (rand-int 20) 10))))))
-;
-;(def population (doall (for [i (range 1000)] (agent ['(), -1]))))
-;
-;(defn print-incomplete 
-;  []
-;  (printf "\nIncomplete: %s\n" (reduce + (map #(if (< (nth % 1) 0) 1 0)
-;                                              (map deref population)))))
-;
-;(time
-; (do
-;     (print-incomplete)
-;   (dorun (map #(send % (fn [[p f]] [(new-pgm) f])) population)) 
-;   (apply await population)
-;   (dorun (map #(send % (fn [[p f]] [p (count (:integer (run-push p (make-push-state))))])) population))
-;   (apply await population)
-;   (print-incomplete)
-;   ))
-
-
-;;;;;;;;;;;;
-;; Integer symbolic regression of x^3 - 2x^2 - x (problem 5 from the trivial geography chapter) with 
-;; minimal integer instructions and an input instruction that uses the auxiliary stack.
-
-
-;(define-registered in (fn [state] (push-item (stack-ref :auxiliary 0 state) :integer state)))
-;
-;(pushgp {
-;         :error-function 
-;         (fn [program]
-;             (doall
-;              (for [input (range 10)]
-;                (let [state (run-push program 
-;                                      (push-item input :auxiliary 
-;                                                 (push-item input :integer
-;                                                            (make-push-state))))
-;                            top-int (top-item :integer state)]
-;                  (if (number? top-int)
-;                      (math/abs (- top-int (- (* input input input) (* 2 input input) input)))
-;                      1000)))))
-;         :atom-generators (list (fn [] (rand-int 10))
-;                                'in
-;                                'integer_div
-;                                'integer_mult
-;                                'integer_add
-;                                'integer_sub)
-;         })
-
-;;;;;;;;;;;;
-;; Integer symbolic regression of factorial, using an input instruction and lots of
-;; other instructions. Hard but solvable. 
-
-
-;(define-registered in (fn [state] (push-item (stack-ref :auxiliary 0 state) :integer state)))
-;
-;(defn factorial 
-;  [n]
-;  ;; Returns the factorial of n. 
-;  (if (< n 2)
-;      1
-;      (* n (factorial (- n 1)))))
-;
-;(pushgp {:error-function (fn [program]
-;                             (doall
-;                              (for [input (range 1 6)]
-;                                (let [state (run-push program
-;                                                      (push-item input :auxiliary
-;                                                                 (push-item input :integer
-;                                                                            (make-push-state))))
-;                                            top-int (top-item :integer state)]
-;                                  (if (number? top-int)
-;                                      (math/abs (- top-int (factorial input)))
-;                                      1000000000))))) ;; big penalty, since errors can be big
-;                         :atom-generators (concat (registered-for-type :integer)
-;                                                  (registered-for-type :exec)
-;                                                  (registered-for-type :boolean)
-;                                                  (list (fn [] (rand-int 100))
-;                                                        'in))
-;                         :max-points 100
-;                         :population-size 10000
-;                         :reproduction-simplifications 2})
-;
-;(let [population (into [] (for [_ (range 1000)] (struct-map individual :program (random-code 100 '(a b c)) 
-;                                                            :total-error (rand-int 100))))]
-;  (time (dotimes [_ 10000] (select population 7 0 0))))
-;
-;(println (->> (make-push-state)
-;              (push-item 'a :code)
-;              (push-item 'b :code)
-;              (push-item 'c :code)
-;              (push-item 'd :code)
-;              (push-item 1 :integer)
-;              (code_shove)
-;              ))
-;
-;(println (->> (make-push-state)
-;              (push-item 'a :code)
-;              (push-item 'b :code)
-;              (push-item 'c :code)
-;              (push-item 'd :code)
-;              (push-item 3 :integer)
-;              (code_shove)
-;              ))
-;
-;(println (->> (make-push-state)
-;              (push-item 'a :code)
-;              (push-item 'b :code)
-;              (push-item 'c :code)
-;              (push-item 'd :code)
-;              (push-item 55 :integer)
-;              (code_shove)
-;              ))
-;
-;(println (->> (make-push-state)
-;              (push-item 'a :code)
-;              (push-item 'b :code)
-;              (push-item 'c :code)
-;              (push-item 'd :code)
-;              (push-item -2 :integer)
-;              (code_shove)
-;              ))
-;
-;(println (->> (make-push-state)
-;              (push-item 101 :integer)
-;              (push-item 102 :integer)
-;              (push-item 103 :integer)
-;              (push-item 0 :integer)
-;              (integer_shove)
-;              ))
-;
-;(println (->> (make-push-state)
-;              (push-item 101 :integer)
-;              (push-item 102 :integer)
-;              (push-item 103 :integer)
-;              (push-item 1 :integer)
-;              (integer_shove)
-;              ))
-
-
-#_(println (->> (make-push-state)
-	      (push-item '(a b c) :code)
-	      (push-item 2 :integer)
-	      (code_extract)))
-
-#_(println (->> (make-push-state)
-	      (push-item '(a b c) :code)
-	      (push-item '(x y z) :code)
-	      (push-item 2 :integer)
-	      (code_insert)))
-
-;(println (subst 1 2 '(1 2 3)))
-;(println (subst '(a b) '(x y) '(1 2 (x y) (3 4 ((x y))) (x y))))
-
-
-;(in-ns 'clojush)
-;(def top-level-push-code false)
-;(def top-level-pop-code false)
-;(in-ns 'clojush-tests)
-
-;(println (run-push '(code_quote (a b) code_quote (x y) code_quote (1 2 (x y) (3 4 ((x y))) (x y)) code_subst) (make-push-state)))
-
-#_(println (->> (make-push-state)
-	      (push-item '(1 2 3) :code)
-	      (push-item 'b :code)
-	      (push-item '(a b (a b (a b) a b)) :code)
-	      (code_subst)))
-
-#_(println (contains-subtree '(1 (2 3) 4) 3))
-#_(println (contains-subtree '(1 (2 (3 4)) x) '(3 4)))
-#_(println (contains-subtree '(1 (2 (3 4)) x) '(2 3)))
-
-#_(println (->> (make-push-state)
-	      (push-item '(1 (2 (a b) 3)) :code)
-	      (push-item '(a b) :code)
-	      (code_contains)))
-
-#_(println (->> (make-push-state)
-	      (push-item '(1 (2 (a b) 3)) :code)
-	      (push-item '(a) :code)
-	      (code_contains)))
-
-#_(println (containing-subtree '(b (c (a)) (d (a))) '(a)) )
-
-#_(println (->> (make-push-state)
-	      (push-item '(a) :code)
-	      (push-item '(b (c (a)) (d (a))) :code)
-	      (code_container)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'a :code)
-	      (push-item '(x x a x x x a x) :code)
-	      (code_position)))
-
-#_(println (->> (make-push-state)
-	      (push-item 'b :code)
-	      (push-item '(x x a x x x a x) :code)
-	      (code_position)))
-
-#_(println (discrepancy '(a b c d) '(a b c d)))
-#_(println (discrepancy '(a b c d e) '(a b c d e)))
-#_(println (discrepancy '(a b c d e) '(a b c d)))
-
-#_(println (->> (make-push-state)
-	      (push-item '(a b c) :code)
-	      (push-item '(a b) :code)
-	      (code_discrepancy)))
-
-#_(println (->> (make-push-state)
-	      (boolean_rand)
-	      (integer_rand)
-	      (float_rand)
-	      (push-item 25 :integer)
-	      (code_rand)
-	      ))
-
-#_(do (def top-level-push-code false)
-    (def top-level-pop-code false)
-    (println (run-push '(code_quote (a b c) code_wrap)
-		       (make-push-state)))
-    (println (run-push '(code_quote (a b c) code_map (code_dup code_list))
-		       (make-push-state)))
-    (println (run-push '(code_quote a code_map (code_dup code_list))
-		       (make-push-state)))
-    )
-
-;; factorial example from push3 spec, translated into clojush
-#_(def top-level-pop-code false)
-#_(println (run-push '(code_quote 
-		     (integer_pop 1)
-		     code_quote 
-		     (code_dup integer_dup 1 integer_sub code_do integer_mult)
-		     integer_dup 2 integer_lt code_if)
-		   (push-item 5 :integer (make-push-state))))
-
-;; pathological quasiquine
-#_(def top-level-push-code false) ;; don't push code initially, must construct
-#_(def top-level-pop-code false) ;; don't pop resulting code
-#_(println (run-push '(1 9 code_quote (integer_pop code_pop code_quote) code_do*range)
-		   (make-push-state)
-		   true))
-
-;(println (run-push '(1 2 tag_integer_123) (make-push-state)))
-
-;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001) (make-push-state)))
-;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_901) (make-push-state)))
-;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001 untag_222) (make-push-state)))
-;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001 untag_222 tagged_123) (make-push-state)))
-;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001 untag_222 tagged_123 integer_add tag_integer_12) (make-push-state)))
- 
-;((tag-instruction-erc [:integer :float] 100))
-
-;(let [c '(+ (* 1 2) (/ 3 4))] (code-at-point c (choose-node-index-with-leaf-probability c)))
-;(let [c (random-code-with-size 1000 '(1))] (time (dotimes [_ 10] (choose-node-index-with-leaf-probability c))))
-;(do (dotimes [_ 1000] (choose-node-index-with-leaf-probability (random-code 100 '(1)))) :no-failures)
-
-;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_code_001 code_dup) (make-push-state)))
-
-;(println (run-push '(1 2 tag_integer_123) (make-push-state)))
-
-#_(println ((tagged-code-macro-erc 'code_append 1000 2 1)))
-
-#_{:tagged_code_macro true :instruction 'clojush/code_append
-                                  :argument_tags [10 20] :result_tags [30]}
-
-#_(println (run-push '(tag_exec_15 (1 2 3) tag_exec_25 (4 5 6)
-                                 {:tagged_code_macro true :instruction code_append
-                                  :argument_tags [10 20] :result_tags [30]})
-                   (make-push-state)))
-#_(println (run-push '(code_quote (1 2 3) code_quote (4 5 6) code_append code_swap) (make-push-state)))
-
-#_(println (run-push (concat '(tag_exec_0 (1 2 3) tag_exec_500 (4 5 6))
-                           (list ((tagged-code-macro-erc 'code_append 1000 2 1))))
-                   (make-push-state)))
-
-;(println (run-push '(1 (2) ((integer_add))) (make-push-state)  false false))
-
-;(println (run-push '(1 (2) ((integer_add))) (make-push-state)  false true))
-
-;(println (run-push '(1 (2) float_add ((integer_add))) (make-push-state)  false true))
-
-;(println (run-push '(1 (2) float_add ((integer_add))) (make-push-state)  false :changes))
-
-;(println (run-push '(true exec_when 1 2) (make-push-state)))
-
-;(println (run-push '(false exec_when 1 2) (make-push-state)))
-
-;(println (run-push '(1 2 3 tag_integer_123 4 5 6 true tagged_when_123) (make-push-state)))
-
-;(println (run-push '(1 2 3 tag_integer_123 4 5 6 false tagged_when_123) (make-push-state)))
-
-(time (dotimes [i 1000] 
-        (run-push '(123 245 integer_swap integer_swap integer_mult integer_dup integer_div)
-                  (make-push-state))))
-
-(time (dotimes [i 1000] 
-        (run-push '(123 245 tag_integer_123 tagged_123 integer_mult integer_dup integer_div)
-                  (make-push-state))))
-
-(time (dotimes [i 1000] 
-        (run-push '(123 245 integer_swap integer_swap)
-                  (make-push-state))))
-
-(time (dotimes [i 1000] 
-        (run-push '(123 245 tag_integer_123 tagged_123)
-                  (make-push-state))))
+;; ;; This is a file of commented-out informal tests (without outputs...)
+;; ;; of functions in coljush.clj.
+
+;; (ns clojush.test.clojush_tests
+;;   (:use [clojush.clojush]
+;;         [clojush.globals]
+;;         [clojush.random]
+;;         [clojush.util]
+;;         [clojush.pushstate]))
+
+;; ;(in-ns 'clojush)
+
+;; ;(println (random-element '(a b c d e)))
+;; ;(println (shuffle '(a b c d e)))
+;; ;(println (decompose 20 6))
+;; ;(println (shuffle (decompose 20 6)))
+;; ;(println (random-code-with-size 20 '(1 2 3)))
+;; ;(println (random-code-with-size 20 (list 3.14 'squid)))
+;; ;(println (random-code-with-size 20 (list 3.14 'squid (fn [] (rand-int 100)))))
+;; ;(println (random-code 100 (list 3.14 'squid (fn [] (rand-int 100)))))
+
+;; #_(time (def p
+;; 	   (for [i (range 1000)]
+;; 	     (random-code 100 (list 'a 1)))))
+
+;; ;(time (reduce + (map count (map ensure-list p))))
+
+;; ;(println (count-points '((this) program (contains (9 points)))))
+
+;; ;(time (println (reduce + (map count-points p))))
+
+;; #_(time (reduce + (for [i (range 100)]
+;; 		  (let [lst (for [j (range 1000)] j)]
+;; 		    (first (shuffle lst))))))
+
+;; ;(println (keep-number-reasonable 10E100))
+;; ;(println (keep-number-reasonable -312987231987329187329187321987231987))
+;; ;(println (count-points '((this) program (contains (9 points)))))
+
+;; ;(dotimes [i 10] (println (code-at-point '(a (b c) d) i)))
+;; ;(println '---)
+;; ;(dotimes [i 10] (println (insert-code-at-point '(a (b c) d) i 'x)))
+;; ;(println '---)
+;; ;(dotimes [i 10] (println (remove-code-at-point '(a (b c) d) i)))
+;; ;(println '---)
+;; ;(dotimes [i 10] (println (remove-code-at-point '(a (b c (e)) d) i)))
+;; ;(println '---)
+;; ;(dotimes [i 10] (println (remove-code-at-point '(a (b c (e f)) d) i)))
+
+;; ;(println (make-push-state))
+
+;; ;(register-instruction 'foo)
+;; ;(register-instruction 'bar)
+;; ;(println registered-instructions)
+
+;; ;(println (macroexpand-1 '(define-registered schmoo (fn [] (println 'hello)))))
+
+;; ;(define-registered schmoo (fn [] (println 'hello)))
+
+;; ;(println registered-instructions)
+;; ;(println instruction-table)
+;; ;(schmoo)
+
+;; ;(println (get-stack :integer (make-push-state)))
+
+;; ;(println (state-pretty-print (make-push-state)))
+
+;; ;(get-stack 'integer (make-schush-state))
+
+;; #_(let [s (make-push-state)]
+;;   (println (push-item 'froggy :code s)))
+
+;; ;(println (top-item :code (push-item 'froggy :code (make-push-state))))
+
+;; ;(println (top-item :integer (make-push-state)))
+
+;; #_(println (stack-ref :integer
+;; 		    1
+;; 		    (push-item 2
+;; 			  :integer
+;; 			  (push-item 1
+;; 				:integer
+;; 				(push-item 0
+;; 				      :integer
+;; 				      (make-push-state))))))
+
+;; #_(loop [n 0
+;;        state (make-push-state)]
+;;   (if (> n 4)
+;;     (do (println state)
+;; 	(println (pop-item :integer state)))
+;;     (recur (inc n)
+;; 	   (push-item n :integer state))))
+
+;; ;(define-registered integer.schmoo (fn [] 0))
+;; ;(define-registered float.schmoo (fn [] 0))
+;; ;(println (registered-for-type :integer))
+
+;; ;(println ((popper :integer) (push-item 2 :integer (push-item 3 :integer (make-push-state)))))
+
+;; ;(println (->> (make-push-state) (push-item 23 :integer) (push-item 100 :integer) (integer_pop)))
+
+;; ;(println (->> (make-push-state) (push-item 23 :integer) (integer_dup)))
+
+;; ;(println (->> (make-push-state) (push-item 1 :integer) (push-item 2 :integer)))
+;; ;(println (->> (make-push-state) (push-item 1 :integer) (push-item 2 :integer) (integer_swap)))
+;; ;(println (->> (make-push-state) (push-item 1 :integer) (integer_swap)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item 'b :code)
+;; 	      (push-item 'c :code)
+;; 	      (code_rot)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item 'b :code)
+;; 	      (push-item 'c :code)
+;; 	      (code_flush)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item 'b :code)
+;; 	      (code_eq)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item 'a :code)
+;; 	      (code_eq)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (code_eq)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item 'b :code)
+;; 	      (code_stackdepth)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item 'b :code)
+;; 	      (push-item 'c :code)
+;; 	      (push-item 'd :code)
+;; 	      (push-item 2 :integer)
+;; 	      (code_yank)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 101 :integer)
+;; 	      (push-item 102 :integer)
+;; 	      (push-item 103 :integer)
+;; 	      (push-item 104 :integer)
+;; 	      (push-item 2 :integer)
+;; 	      (integer_yank)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item 'b :code)
+;; 	      (push-item 'c :code)
+;; 	      (push-item 'd :code)
+;; 	      (push-item 2 :integer)
+;; 	      (code_yankdup)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 101 :integer)
+;; 	      (push-item 102 :integer)
+;; 	      (push-item 103 :integer)
+;; 	      (push-item 104 :integer)
+;; 	      (push-item 2 :integer)
+;; 	      (integer_yankdup)))
+
+;; ;(println (run-push '(1 2 integer_dup) (make-push-state) true))
+
+;; ;(println (run-push '(1 2 integer_add) (make-push-state)))
+;; ;(println (run-push '(1 integer_add) (make-push-state)))
+
+;; ;(println (run-push '(100 1 integer_sub) (make-push-state)))
+
+;; ;(println (run-push '(10.0 5.0 float_mult) (make-push-state)))
+
+;; ;(println (run-push '(10.0 6.0 float_div) (make-push-state)))
+;; ;(println (run-push '(-10.0 6.0 float_div) (make-push-state)))
+;; ;(println (run-push '(10 6 integer_div) (make-push-state)))
+;; ;(println (run-push '(-10 6 integer_div) (make-push-state)))
+;; ;(println (run-push '(10.0 0.0 float_div) (make-push-state)))
+;; ;(println (run-push '(10 0 integer_div) (make-push-state)))
+
+;; ;(println (run-push '((10.0 (5.0 float_mult))) (make-push-state)))
+
+;; ;(println (run-push '(10.0 6.0 float_mod) (make-push-state)))
+;; ;(println (run-push '(-10.0 6.0 float_mod) (make-push-state)))
+;; ;(println (run-push '(10 6 integer_mod) (make-push-state)))
+;; ;(println (run-push '(-10 6 integer_mod) (make-push-state)))
+;; ;(println (run-push '(10.0 0.0 float_mod) (make-push-state)))
+;; ;(println (run-push '(10 0 integer_mod) (make-push-state)))
+
+;; ;(println (run-push '(10.0 11.0 float_lt) (make-push-state)))
+;; ;(println (run-push '(10.0 1.0 float_lt) (make-push-state)))
+;; ;(println (run-push '(10.0 11.0 float_gt) (make-push-state)))
+;; ;(println (run-push '(10.0 1.0 float_gt) (make-push-state)))
+
+;; ;(println (run-push '(false integer_fromboolean) (make-push-state)))
+;; ;(println (run-push '(true integer_fromboolean) (make-push-state)))
+;; ;(println (run-push '(integer_fromboolean) (make-push-state)))
+
+;; ;(println (run-push '(false float_fromboolean) (make-push-state)))
+;; ;(println (run-push '(true float_fromboolean) (make-push-state)))
+;; ;(println (run-push '(float_fromboolean) (make-push-state)))
+
+;; ;(println (run-push '(3.14 integer_fromfloat) (make-push-state)))
+;; ;(println (run-push '(3 float_frominteger) (make-push-state)))
+
+;; ;(println (run-push '(1 2 integer_min) (make-push-state)))
+;; ;(println (run-push '(2 1 integer_min) (make-push-state)))
+;; ;(println (run-push '(1.0 2.0 float_min) (make-push-state)))
+;; ;(println (run-push '(2.0 1.0 float_min) (make-push-state)))
+
+;; ;(println (run-push '(1 2 integer_max) (make-push-state)))
+;; ;(println (run-push '(2 1 integer_max) (make-push-state)))
+;; ;(println (run-push '(1.0 2.0 float_max) (make-push-state)))
+;; ;(println (run-push '(2.0 1.0 float_max) (make-push-state)))
+
+;; ;(println (run-push '(3.141592 float_sin) (make-push-state)))
+;; ;(println (run-push '(3.141592 float_cos) (make-push-state)))
+;; ;(println (run-push '(3.141592 float_tan) (make-push-state)))
+
+;; ;(println (run-push '(true false boolean_and) (make-push-state)))
+;; ;(println (run-push '(true true boolean_and) (make-push-state)))
+;; ;(println (run-push '(true boolean_and) (make-push-state)))
+;; ;(println (run-push '(true false boolean_or) (make-push-state)))
+;; ;(println (run-push '(false false boolean_or) (make-push-state)))
+;; ;(println (run-push '(true boolean_or) (make-push-state)))
+;; ;(println (run-push '(true boolean_not) (make-push-state)))
+
+;; ;(println (run-push '(0.0 boolean_fromfloat) (make-push-state)))
+;; ;(println (run-push '(10.0 boolean_fromfloat) (make-push-state)))
+;; ;(println (run-push '(0 boolean_frominteger) (make-push-state)))
+;; ;(println (run-push '(10 boolean_frominteger) (make-push-state)))
+
+
+
+;; ;(dotimes [_ 100]
+;; #_(println (let [c (random-code 100 (concat registered-instructions
+;; 					    (list (fn [] (- (rand 2) 1))
+;; 					       (fn [] (- (rand-int 20) 10)))))]
+;; 	   (println c)
+;; 	   (run-push c
+;; 		     (make-push-state)
+;; 		     true
+;; 		     )))
+;; ;)
+
+
+;; ;(defn new-pgm
+;; ;  []
+;; ;  (random-code 100 (concat registered-instructions
+;; ;                           (list (fn [] (- (rand 2) 1))
+;; ;                                 (fn [] (- (rand-int 20) 10))))))
+;; ;
+;; ;(def population (doall (for [i (range 1000)] (agent ['(), -1]))))
+;; ;
+;; ;(defn print-incomplete
+;; ;  []
+;; ;  (printf "\nIncomplete: %s\n" (reduce + (map #(if (< (nth % 1) 0) 1 0)
+;; ;                                              (map deref population)))))
+;; ;
+;; ;(time
+;; ; (do
+;; ;     (print-incomplete)
+;; ;   (dorun (map #(send % (fn [[p f]] [(new-pgm) f])) population))
+;; ;   (apply await population)
+;; ;   (dorun (map #(send % (fn [[p f]] [p (count (:integer (run-push p (make-push-state))))])) population))
+;; ;   (apply await population)
+;; ;   (print-incomplete)
+;; ;   ))
+
+
+;; ;;;;;;;;;;;;
+;; ;; Integer symbolic regression of x^3 - 2x^2 - x (problem 5 from the trivial geography chapter) with
+;; ;; minimal integer instructions and an input instruction that uses the auxiliary stack.
+
+
+;; ;(define-registered in (fn [state] (push-item (stack-ref :auxiliary 0 state) :integer state)))
+;; ;
+;; ;(pushgp {
+;; ;         :error-function
+;; ;         (fn [program]
+;; ;             (doall
+;; ;              (for [input (range 10)]
+;; ;                (let [state (run-push program
+;; ;                                      (push-item input :auxiliary
+;; ;                                                 (push-item input :integer
+;; ;                                                            (make-push-state))))
+;; ;                            top-int (top-item :integer state)]
+;; ;                  (if (number? top-int)
+;; ;                      (math/abs (- top-int (- (* input input input) (* 2 input input) input)))
+;; ;                      1000)))))
+;; ;         :atom-generators (list (fn [] (rand-int 10))
+;; ;                                'in
+;; ;                                'integer_div
+;; ;                                'integer_mult
+;; ;                                'integer_add
+;; ;                                'integer_sub)
+;; ;         })
+
+;; ;;;;;;;;;;;;
+;; ;; Integer symbolic regression of factorial, using an input instruction and lots of
+;; ;; other instructions. Hard but solvable.
+
+
+;; ;(define-registered in (fn [state] (push-item (stack-ref :auxiliary 0 state) :integer state)))
+;; ;
+;; ;(defn factorial
+;; ;  [n]
+;; ;  ;; Returns the factorial of n.
+;; ;  (if (< n 2)
+;; ;      1
+;; ;      (* n (factorial (- n 1)))))
+;; ;
+;; ;(pushgp {:error-function (fn [program]
+;; ;                             (doall
+;; ;                              (for [input (range 1 6)]
+;; ;                                (let [state (run-push program
+;; ;                                                      (push-item input :auxiliary
+;; ;                                                                 (push-item input :integer
+;; ;                                                                            (make-push-state))))
+;; ;                                            top-int (top-item :integer state)]
+;; ;                                  (if (number? top-int)
+;; ;                                      (math/abs (- top-int (factorial input)))
+;; ;                                      1000000000))))) ;; big penalty, since errors can be big
+;; ;                         :atom-generators (concat (registered-for-type :integer)
+;; ;                                                  (registered-for-type :exec)
+;; ;                                                  (registered-for-type :boolean)
+;; ;                                                  (list (fn [] (rand-int 100))
+;; ;                                                        'in))
+;; ;                         :max-points 100
+;; ;                         :population-size 10000
+;; ;                         :reproduction-simplifications 2})
+;; ;
+;; ;(let [population (into [] (for [_ (range 1000)] (struct-map individual :program (random-code 100 '(a b c))
+;; ;                                                            :total-error (rand-int 100))))]
+;; ;  (time (dotimes [_ 10000] (select population 7 0 0))))
+;; ;
+;; ;(println (->> (make-push-state)
+;; ;              (push-item 'a :code)
+;; ;              (push-item 'b :code)
+;; ;              (push-item 'c :code)
+;; ;              (push-item 'd :code)
+;; ;              (push-item 1 :integer)
+;; ;              (code_shove)
+;; ;              ))
+;; ;
+;; ;(println (->> (make-push-state)
+;; ;              (push-item 'a :code)
+;; ;              (push-item 'b :code)
+;; ;              (push-item 'c :code)
+;; ;              (push-item 'd :code)
+;; ;              (push-item 3 :integer)
+;; ;              (code_shove)
+;; ;              ))
+;; ;
+;; ;(println (->> (make-push-state)
+;; ;              (push-item 'a :code)
+;; ;              (push-item 'b :code)
+;; ;              (push-item 'c :code)
+;; ;              (push-item 'd :code)
+;; ;              (push-item 55 :integer)
+;; ;              (code_shove)
+;; ;              ))
+;; ;
+;; ;(println (->> (make-push-state)
+;; ;              (push-item 'a :code)
+;; ;              (push-item 'b :code)
+;; ;              (push-item 'c :code)
+;; ;              (push-item 'd :code)
+;; ;              (push-item -2 :integer)
+;; ;              (code_shove)
+;; ;              ))
+;; ;
+;; ;(println (->> (make-push-state)
+;; ;              (push-item 101 :integer)
+;; ;              (push-item 102 :integer)
+;; ;              (push-item 103 :integer)
+;; ;              (push-item 0 :integer)
+;; ;              (integer_shove)
+;; ;              ))
+;; ;
+;; ;(println (->> (make-push-state)
+;; ;              (push-item 101 :integer)
+;; ;              (push-item 102 :integer)
+;; ;              (push-item 103 :integer)
+;; ;              (push-item 1 :integer)
+;; ;              (integer_shove)
+;; ;              ))
+
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item '(a b c) :code)
+;; 	      (push-item 2 :integer)
+;; 	      (code_extract)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item '(a b c) :code)
+;; 	      (push-item '(x y z) :code)
+;; 	      (push-item 2 :integer)
+;; 	      (code_insert)))
+
+;; ;(println (subst 1 2 '(1 2 3)))
+;; ;(println (subst '(a b) '(x y) '(1 2 (x y) (3 4 ((x y))) (x y))))
+
+
+;; ;(in-ns 'clojush)
+;; ;(def top-level-push-code false)
+;; ;(def top-level-pop-code false)
+;; ;(in-ns 'clojush-tests)
+
+;; ;(println (run-push '(code_quote (a b) code_quote (x y) code_quote (1 2 (x y) (3 4 ((x y))) (x y)) code_subst) (make-push-state)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item '(1 2 3) :code)
+;; 	      (push-item 'b :code)
+;; 	      (push-item '(a b (a b (a b) a b)) :code)
+;; 	      (code_subst)))
+
+;; #_(println (contains-subtree '(1 (2 3) 4) 3))
+;; #_(println (contains-subtree '(1 (2 (3 4)) x) '(3 4)))
+;; #_(println (contains-subtree '(1 (2 (3 4)) x) '(2 3)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item '(1 (2 (a b) 3)) :code)
+;; 	      (push-item '(a b) :code)
+;; 	      (code_contains)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item '(1 (2 (a b) 3)) :code)
+;; 	      (push-item '(a) :code)
+;; 	      (code_contains)))
+
+;; #_(println (containing-subtree '(b (c (a)) (d (a))) '(a)) )
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item '(a) :code)
+;; 	      (push-item '(b (c (a)) (d (a))) :code)
+;; 	      (code_container)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'a :code)
+;; 	      (push-item '(x x a x x x a x) :code)
+;; 	      (code_position)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item 'b :code)
+;; 	      (push-item '(x x a x x x a x) :code)
+;; 	      (code_position)))
+
+;; #_(println (discrepancy '(a b c d) '(a b c d)))
+;; #_(println (discrepancy '(a b c d e) '(a b c d e)))
+;; #_(println (discrepancy '(a b c d e) '(a b c d)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (push-item '(a b c) :code)
+;; 	      (push-item '(a b) :code)
+;; 	      (code_discrepancy)))
+
+;; #_(println (->> (make-push-state)
+;; 	      (boolean_rand)
+;; 	      (integer_rand)
+;; 	      (float_rand)
+;; 	      (push-item 25 :integer)
+;; 	      (code_rand)
+;; 	      ))
+
+;; #_(do (def top-level-push-code false)
+;;     (def top-level-pop-code false)
+;;     (println (run-push '(code_quote (a b c) code_wrap)
+;; 		       (make-push-state)))
+;;     (println (run-push '(code_quote (a b c) code_map (code_dup code_list))
+;; 		       (make-push-state)))
+;;     (println (run-push '(code_quote a code_map (code_dup code_list))
+;; 		       (make-push-state)))
+;;     )
+
+;; ;; factorial example from push3 spec, translated into clojush
+;; #_(def top-level-pop-code false)
+;; #_(println (run-push '(code_quote
+;; 		     (integer_pop 1)
+;; 		     code_quote
+;; 		     (code_dup integer_dup 1 integer_sub code_do integer_mult)
+;; 		     integer_dup 2 integer_lt code_if)
+;; 		   (push-item 5 :integer (make-push-state))))
+
+;; ;; pathological quasiquine
+;; #_(def top-level-push-code false) ;; don't push code initially, must construct
+;; #_(def top-level-pop-code false) ;; don't pop resulting code
+;; #_(println (run-push '(1 9 code_quote (integer_pop code_pop code_quote) code_do*range)
+;; 		   (make-push-state)
+;; 		   true))
+
+;; ;(println (run-push '(1 2 tag_integer_123) (make-push-state)))
+
+;; ;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001) (make-push-state)))
+;; ;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_901) (make-push-state)))
+;; ;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001 untag_222) (make-push-state)))
+;; ;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001 untag_222 tagged_123) (make-push-state)))
+;; ;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_001 untag_222 tagged_123 integer_add tag_integer_12) (make-push-state)))
+
+;; ;((tag-instruction-erc [:integer :float] 100))
+
+;; ;(let [c '(+ (* 1 2) (/ 3 4))] (code-at-point c (choose-node-index-with-leaf-probability c)))
+;; ;(let [c (random-code-with-size 1000 '(1))] (time (dotimes [_ 10] (choose-node-index-with-leaf-probability c))))
+;; ;(do (dotimes [_ 1000] (choose-node-index-with-leaf-probability (random-code 100 '(1)))) :no-failures)
+
+;; ;(println (run-push '(1 2 integer_add tag_integer_123 99 tagged_code_001 code_dup) (make-push-state)))
+
+;; ;(println (run-push '(1 2 tag_integer_123) (make-push-state)))
+
+;; #_(println ((tagged-code-macro-erc 'code_append 1000 2 1)))
+
+;; #_{:tagged_code_macro true :instruction 'clojush/code_append
+;;                                   :argument_tags [10 20] :result_tags [30]}
+
+;; #_(println (run-push '(tag_exec_15 (1 2 3) tag_exec_25 (4 5 6)
+;;                                  {:tagged_code_macro true :instruction code_append
+;;                                   :argument_tags [10 20] :result_tags [30]})
+;;                    (make-push-state)))
+;; #_(println (run-push '(code_quote (1 2 3) code_quote (4 5 6) code_append code_swap) (make-push-state)))
+
+;; #_(println (run-push (concat '(tag_exec_0 (1 2 3) tag_exec_500 (4 5 6))
+;;                            (list ((tagged-code-macro-erc 'code_append 1000 2 1))))
+;;                    (make-push-state)))
+
+;; ;(println (run-push '(1 (2) ((integer_add))) (make-push-state)  false false))
+
+;; ;(println (run-push '(1 (2) ((integer_add))) (make-push-state)  false true))
+
+;; ;(println (run-push '(1 (2) float_add ((integer_add))) (make-push-state)  false true))
+
+;; ;(println (run-push '(1 (2) float_add ((integer_add))) (make-push-state)  false :changes))
+
+;; ;(println (run-push '(true exec_when 1 2) (make-push-state)))
+
+;; ;(println (run-push '(false exec_when 1 2) (make-push-state)))
+
+;; ;(println (run-push '(1 2 3 tag_integer_123 4 5 6 true tagged_when_123) (make-push-state)))
+
+;; ;(println (run-push '(1 2 3 tag_integer_123 4 5 6 false tagged_when_123) (make-push-state)))
+
+;; (time (dotimes [i 1000]
+;;         (run-push '(123 245 integer_swap integer_swap integer_mult integer_dup integer_div)
+;;                   (make-push-state))))
+
+;; (time (dotimes [i 1000]
+;;         (run-push '(123 245 tag_integer_123 tagged_123 integer_mult integer_dup integer_div)
+;;                   (make-push-state))))
+
+;; (time (dotimes [i 1000]
+;;         (run-push '(123 245 integer_swap integer_swap)
+;;                   (make-push-state))))
+
+;; (time (dotimes [i 1000]
+;;         (run-push '(123 245 tag_integer_123 tagged_123)
+;;                   (make-push-state))))

--- a/test/clojush/test/stress_test.clj
+++ b/test/clojush/test/stress_test.clj
@@ -1,30 +1,30 @@
-(ns clojush.test.stress_test
-  (:use [clojush.random]
-        [clojush.pushstate]
-        [clojush.interpreter]))
+;; (ns clojush.test.stress_test
+;;   (:use [clojush.random]
+;;         [clojush.pushstate]
+;;         [clojush.interpreter]))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; stress test
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; ;; stress test
 
-(defn stress-test
-  "Performs a stress test of the registered instructions by generating and running n
-   random programs. For more thorough testing and debugging of Push instructions you many
-   want to un-comment code in execute-instruction that will allow you to look at recently
-   executed instructions and the most recent state after an error. That code burns memory,
-   however, so it is normally commented out. You might also want to comment out the handling
-   of nil values in execute-instruction, do see if any instructions are introducing nils."
-  [n]
-  (let [completely-random-program
-        (fn []
-          (random-code 100 (concat @registered-instructions
-                                   (list (fn [] (lrand-int 100))
-                                         (fn [] (lrand))))))]
-    (loop [i 0 p (completely-random-program)]
-      (if (>= i n)
-        (println :no-errors-found-in-stress-test)
-        (let [result (run-push p (make-push-state) false)]
-          (if result
-            (recur (inc i) (completely-random-program))
-            (println p)))))))
+;; (defn stress-test
+;;   "Performs a stress test of the registered instructions by generating and running n
+;;    random programs. For more thorough testing and debugging of Push instructions you many
+;;    want to un-comment code in execute-instruction that will allow you to look at recently
+;;    executed instructions and the most recent state after an error. That code burns memory,
+;;    however, so it is normally commented out. You might also want to comment out the handling
+;;    of nil values in execute-instruction, do see if any instructions are introducing nils."
+;;   [n]
+;;   (let [completely-random-program
+;;         (fn []
+;;           (random-code 100 (concat @registered-instructions
+;;                                    (list (fn [] (lrand-int 100))
+;;                                          (fn [] (lrand))))))]
+;;     (loop [i 0 p (completely-random-program)]
+;;       (if (>= i n)
+;;         (println :no-errors-found-in-stress-test)
+;;         (let [result (run-push p (make-push-state) false)]
+;;           (if result
+;;             (recur (inc i) (completely-random-program))
+;;             (println p)))))))
 
-;(stress-test 10000)
+;; ;(stress-test 10000)

--- a/test/clojush/test/wiring_test.clj
+++ b/test/clojush/test/wiring_test.clj
@@ -1,0 +1,8 @@
+(ns clojush.test.wiring_test
+  (:use clojure.test      ;; No harm in retaining this
+        ; midje.sweet
+        ))
+
+(deftest wiring
+  (testing "Can we run tests?"
+    (is (= (+ 2 3) 5))))

--- a/test/clojush/test/wiring_test.clj
+++ b/test/clojush/test/wiring_test.clj
@@ -1,8 +1,19 @@
-(ns clojush.test.wiring_test
+; To run these tests with autotest use:
+;
+;    lein midje :autotest test
+;
+; This runs everything in the test sub-directory but
+; _doesn't_ run all the stuff in src, which midje tries
+; to run by default, which breaks the world.
+
+(ns clojush.test.wiring-test
   (:use clojure.test      ;; No harm in retaining this
-        ; midje.sweet
+        midje.sweet
         ))
 
 (deftest wiring
   (testing "Can we run tests?"
     (is (= (+ 2 3) 5))))
+
+(fact "addition works"
+  (+ 2 3) => 5)


### PR DESCRIPTION
This adds a simple function `push-state-from-stacks` to quickly build complex arbitrary `push-state` given a map that contains stacks with desired contents.

The call structure is (for example)

``` clojure
(push-state-from-stacks :integer '(1 2) :boolean '(false) :char '(\f \w \i \w)
```

and the resulting `push-state` has the indicated stacks set to the values given, and the result left as `nil` values.

Note (and see the midje facts): you can assign more or less anything to any "stack" key. I assume this is innocuous, as long as the standard functions only examine known named stack symbols from `clojush.globals/push-types`.