### PR TITLE
Added random replacement info to CSV output

### DIFF
--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -336,6 +336,4 @@ be set globally in the future."
                                          (:ancestors parent1)))
            :is-random-replacement
            (if competent false true)
-           :genetic-operators
-           (if competent :autoconstruction :random)
       )))

--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -71,7 +71,7 @@
                                         (integer? const) (round (perturb-with-gaussian-noise uniform-mutation-int-gaussian-standard-deviation const))
                                         (string? const) (string-tweak const)
                                         (or (= const true) (= const false)) (lrand-nth [true false])
-                                        :else (:instruction (first (random-plush-genome 1 atom-generators argmap))))))))               
+                                        :else (:instruction (first (random-plush-genome 1 atom-generators argmap))))))))
         token-mutator (fn [token]
                         (if (< (lrand) uniform-mutation-rate)
                           (if (< (lrand) uniform-mutation-constant-tweak-rate)
@@ -144,7 +144,7 @@
   "Returns the individual with each element of its genome possibly deleted, with probability
 given by uniform-deletion-rate."
   [ind {:keys [uniform-deletion-rate maintain-ancestors]}]
-  (let [new-genome (filter identity 
+  (let [new-genome (filter identity
                            (map #(if (< (lrand) uniform-deletion-rate) % nil)
                                 (:genome ind)))]
     (make-individual :genome new-genome
@@ -240,11 +240,11 @@ given by uniform-deletion-rate."
 ;; NOTE: EXPERIMENTAL!
 
 (defn process-genome-for-autoconstruction
-  "Replaces input instructions with noops and replaces autoconstructive_<type>_rand with 
+  "Replaces input instructions with noops and replaces autoconstructive_<type>_rand with
 <type>_rand if deterministic? is false."
   [genome deterministic?]
   (let [input-instruction? (fn [instruction]
-                             (and (symbol? instruction) 
+                             (and (symbol? instruction)
                                   (or (re-seq #"in\d+" (name instruction)) ;; from input-output
                                       (re-seq #"in_dm" (name instruction)))))] ;; from digital-multiplier
     (map (fn [instruction-map]
@@ -285,7 +285,7 @@ the resulting top genome."
 genome g."
   [g argmap]
   (ensure-list
-    (list-to-open-close-sequence 
+    (list-to-open-close-sequence
       (translate-plush-genome-to-push-program {:genome g} argmap))))
 
 (defn expressed-difference
@@ -312,12 +312,12 @@ programs encoded by genomes g1 and g2."
                     (expressed-difference child2 gc2b argmap)))))
 
 (defn autoconstruction
-  "Returns a genome for a child produced either by autoconstruction (executing parent1 
+  "Returns a genome for a child produced either by autoconstruction (executing parent1
 with both parents on top of the genome stack and also available via input instructions)
-or by cloning. In either case if the child is not reproductively competent then a random 
+or by cloning. In either case if the child is not reproductively competent then a random
 genome is returned instead. The construct/clone ration is hardcoded here, but might
 be set globally in the future."
-  [parent1 parent2 {:keys [maintain-ancestors atom-generators max-genome-size-in-initial-program error-function] 
+  [parent1 parent2 {:keys [maintain-ancestors atom-generators max-genome-size-in-initial-program error-function]
                     :as argmap}]
   (let [construct-clone-ratio 0.9 ;; maybe make this a global parameter
         parent1-genome (:genome parent1)
@@ -334,5 +334,8 @@ be set globally in the future."
                             :ancestors (if maintain-ancestors
                                          (cons (:genome parent1) (:ancestors parent1))
                                          (:ancestors parent1)))
-           :random-replacement-for-reproductively-incompetent-genome 
-           (if competent false true))))
+           :is-random-replacement
+           (if competent false true)
+           :genetic-operators
+           (if competent :autoconstruction :random)
+      )))

--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -71,7 +71,7 @@
   [population generation {:keys [csv-log-filename csv-columns]}]
   (let [columns (concat [:uuid]
                         (filter #(some #{%} csv-columns)
-                                [:generation :location :parent-uuids :genetic-operators :push-program-size :plush-genome-size :push-program :plush-genome :total-error]))]
+                                [:generation :location :parent-uuids :genetic-operators :push-program-size :plush-genome-size :push-program :plush-genome :total-error :is-random-replacement]))]
     (when (zero? generation)
       (with-open [csv-file (io/writer csv-log-filename :append false)]
         (csv/write-csv csv-file
@@ -388,8 +388,8 @@
                                                    (repeat (- population-size (count @selection-counts)) 0))))
       (reset! selection-counts {}))
     (when autoconstructive
-      (println "Number of random replacements for reproductively incompetent individuals:" 
-               (count (filter :random-replacement-for-reproductively-incompetent-genome population))))
+      (println "Number of random replacements for reproductively incompetent individuals:"
+               (count (filter :is-random-replacement population))))
     (println "--- Run Statistics ---")
     (println "Number of program evaluations used so far:" @evaluations-count)
     (println "Number of point (instruction) evaluations so far:" point-evaluations-before-report)
@@ -463,7 +463,7 @@
    {:keys [error-function final-report-simplifications report-simplifications
            print-ancestors-of-solution problem-specific-report]}]
   (printf "\n\nSUCCESS at generation %s\nSuccessful program: %s\nErrors: %s\nTotal error: %s\nHistory: %s\nSize: %s\n\n"
-          generation (pr-str (not-lazy (:program best))) (not-lazy (:errors best)) (:total-error best) 
+          generation (pr-str (not-lazy (:program best))) (not-lazy (:errors best)) (:total-error best)
           (not-lazy (:history best)) (count-points (:program best)))
   (when print-ancestors-of-solution
     (printf "\nAncestors of solution:\n")


### PR DESCRIPTION
Changed the keyword `:random-replacement-for-reproductively-incompetent-genome` to the more manageable `:is-random-replacement`, and added that to the list of values that can be printed in CVS output files.

This also removes some dangling white-space on several lines in `genetic_operators.clj`. I tried figuring out how to use merge to ignore the whitespace, but never got anywhere. If this is too much of a problem I could undo the whitespace changes by hand.