### PR TITLE
Add initial travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: clojure
+script:
+  # check fails because of "Duplicate Push instruction defined:boolean_and"
+  # - lein check
+  - lein test
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Clojush
 =======
 
+[![Build Status](https://travis-ci.org/lspector/Clojush.svg?branch=master)](https://travis-ci.org/lspector/Clojush)
+
 Lee Spector (lspector@hampshire.edu), started 20100227
 [See version history](https://github.com/lspector/Clojush/commits/master).
 Older version history is in old-version-history.txt.


### PR DESCRIPTION
To add travis CI builds you need to [create a Travis account with your github, and enable this repository](http://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A). 

I have disabled running `lein check` because it currently fails, but `lein test` does pass. Once this is added, we can add more advanced linting (#163)  and doc generation (#164)