### PR TITLE
Add auto generated docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+bin/*
+target/*
+doc/*

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ lib/
 *.csv
 *.json
 .lein-failures
+doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ script:
   # check fails because of "Duplicate Push instruction defined:boolean_and"
   # - lein check
   - lein test
+after_success:
+  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && ./deploy-docs.sh
+
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Clojush
 =======
 
 [![Build Status](https://travis-ci.org/lspector/Clojush.svg?branch=master)](https://travis-ci.org/lspector/Clojush)
+[![API Docs](https://img.shields.io/badge/api%20docs-master-blue.svg)](http://lspector.github.io/Clojush/)
 
 Lee Spector (lspector@hampshire.edu), started 20100227
 [See version history](https://github.com/lspector/Clojush/commits/master).
@@ -83,6 +84,20 @@ on the method that you use to launch your code.
 
 An additional tutorial is available in src/clojush/problems/demos/tutorial.clj.
 
+## Docs
+
+Docs are auto generated from function metadata using [`codox`](https://github.com/weavejester/codox).
+
+On every commit to master, the docs are automatically regenerated and pushed
+to [github pages](http://lspector.github.io/Clojush/), through Travis.
+
+To generate them locally run `lein doc` and then open `doc/index.html`.
+
+Currently generating the docs have some unintended side effects of running some examples,
+[because we couldn't figure out how stop codox from loading all the files](https://github.com/weavejester/codox/issues/100).
+
+In the metadata, you can [skip functions](https://github.com/weavejester/codox#metadata-options)
+and also [link to other functions](https://github.com/weavejester/codox#docstring-formats).
 
 Description
 -----------

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# print all lines of script as they are run
+set -o xtrace
+
+lein doc
+
+env GIT_DEPLOY_REPO=https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG.git GIT_DEPLOY_DIR=doc GIT_DEPLOY_EMAIL=_@_ ./deploy.sh --verbose

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# modified from https://github.com/X1011/git-directory-deploy/raw/master/deploy.sh
+# changed to support automatically intializing, if it deteched the remote branch didnt exist
+set -o errexit #abort if any command fails
+
+main() {
+	deploy_directory=${GIT_DEPLOY_DIR:-dist}
+	deploy_branch=${GIT_DEPLOY_BRANCH:-gh-pages}
+
+	#if no user identity is already set in the current git environment, use this:
+	default_username=${GIT_DEPLOY_USERNAME:-deploy.sh}
+	default_email=${GIT_DEPLOY_EMAIL:-}
+
+	#repository to deploy to. must be readable and writable.
+	repo=${GIT_DEPLOY_REPO:-origin}
+
+	# Parse arg flags
+	while : ; do
+		if [[ $1 = "-v" || $1 = "--verbose" ]]; then
+			verbose=true
+			shift
+		elif [[ $1 = "-s" || $1 = "--setup" ]]; then
+			setup=true
+			shift
+		elif [[ $1 = "-e" || $1 = "--allow-empty" ]]; then
+			allow_empty=true
+			shift
+		else
+			break
+		fi
+	done
+
+	enable_expanded_output
+
+	if ! git diff --exit-code --quiet --cached; then
+		echo Aborting due to uncommitted changes in the index >&2
+		exit 1
+	fi
+
+	commit_title=`git log -n 1 --format="%s" HEAD`
+	commit_hash=`git log -n 1 --format="%H" HEAD`
+	previous_branch=`git rev-parse --abbrev-ref HEAD`
+
+	set_user_id
+
+	if [ $setup ]; then
+		setup
+		exit
+	fi
+
+	if [ ! -d "$deploy_directory" ]; then
+		echo "Deploy directory '$deploy_directory' does not exist. Aborting." >&2
+		exit 1
+	fi
+
+	if [[ -z `ls -A "$deploy_directory" 2> /dev/null` && -z $allow_empty ]]; then
+		echo "Deploy directory '$deploy_directory' is empty. Aborting. If you're sure you want to deploy an empty tree, use the -e flag." >&2
+		exit 1
+	fi
+
+	disable_expanded_output
+	if ! git fetch --force $repo $deploy_branch:$deploy_branch; then
+		enable_expanded_output
+		setup
+		exit
+	fi
+	enable_expanded_output
+
+	#make deploy_branch the current branch
+	git symbolic-ref HEAD refs/heads/$deploy_branch
+
+	#put the previously committed contents of deploy_branch branch into the index
+	git --work-tree "$deploy_directory" reset --mixed --quiet
+
+	git --work-tree "$deploy_directory" add --all
+
+	set +o errexit
+	diff=$(git --work-tree "$deploy_directory" diff --exit-code --quiet HEAD)$?
+	set -o errexit
+	case $diff in
+		0) echo No changes to files in $deploy_directory. Skipping commit.;;
+		1)
+			git --work-tree "$deploy_directory" commit -m \
+				"publish: $commit_title"$'\n\n'"generated from commit $commit_hash"
+
+			disable_expanded_output
+			#--quiet is important here to avoid outputting the repo URL, which may contain a secret token
+			git push --quiet $repo $deploy_branch
+			enable_expanded_output
+			;;
+		*)
+			echo git diff exited with code $diff. Aborting. Staying on branch $deploy_branch so you can debug. To switch back to master, use: git symbolic-ref HEAD refs/heads/master && git reset --mixed >&2
+			exit $diff
+			;;
+	esac
+
+	restore_head
+}
+
+setup() {
+	mkdir -p "$deploy_directory"
+	git --work-tree "$deploy_directory" checkout --orphan $deploy_branch
+	git --work-tree "$deploy_directory" rm -r "*"
+	git --work-tree "$deploy_directory" add --all
+	git --work-tree "$deploy_directory" commit -m "initial publish"$'\n\n'"generated from commit $commit_hash"
+	git push $repo $deploy_branch
+	restore_head
+}
+
+#echo expanded commands as they are executed (for debugging)
+enable_expanded_output() {
+	if [ $verbose ]; then
+		set -o xtrace
+		set +o verbose
+	fi
+}
+
+#this is used to avoid outputting the repo URL, which may contain a secret token
+disable_expanded_output() {
+	if [ $verbose ]; then
+		set +o xtrace
+		set -o verbose
+	fi
+}
+
+set_user_id() {
+	if [[ -z `git config user.name` ]]; then
+		git config user.name "$default_username"
+	fi
+	if [[ -z `git config user.email` ]]; then
+		git config user.email "$default_email"
+	fi
+}
+
+restore_head() {
+	if [[ $previous_branch = "HEAD" ]]; then
+		#we weren't on any branch before, so just set HEAD back to the commit it was on
+		git update-ref --no-deref HEAD $commit_hash $deploy_branch
+	else
+		git symbolic-ref HEAD refs/heads/$previous_branch
+	fi
+
+	git reset --mixed
+}
+
+filter() {
+	sed -e "s|$repo|\$repo|g"
+}
+
+sanitize() {
+	"$@" 2> >(filter 1>&2) | filter
+}
+
+[[ $1 = --source-only ]] || main "$@"

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,11 @@
                  [clojure-csv "2.0.1"]
                  [org.clojure/data.json "0.2.6"]
                  [clj-random "0.1.7"]]
+  :plugins [[codox "0.8.14"]]
+  :codox {:src-dir-uri "http://github.com/lspector/Clojush/blob/master/"
+          :src-linenum-anchor-prefix "L"
+          ; :exclude #"^clojush\.problems\."
+          :defaults {:doc/format :markdown}}
   :dev-dependencies [[lein-ccw "1.2.0"][lein-midje "3.1.3"]]
   :profiles {:dev {:dependencies [[midje "1.7.0"]]}}
   ;;;;;;;;;; jvm settings for high performance, using most of the machine's RAM


### PR DESCRIPTION
I have added support for building docs with [codox](https://github.com/weavejester/codox).

In order to get this working, you need to:

1) Add a github API token to Travis as a secret variable, so that it can push the `gh-pages` branch to your repository when it generates the docs. You can add the variable [here](https://travis-ci.org/lspector/Clojush/settings). It should be named `GITHUB_TOKEN` and the value should be the token. To generate a new token, go [here](https://github.com/settings/tokens/new). You can give it any description and it only needs the "public_repo" checked, because it just going to be pushing to this repo.
2) Merge this pull request.

They are [currently working](http://saulshanabrook.github.io/Clojush/) on my fork:

![screen shot 2015-10-13 at 5 40 51 pm](https://cloud.githubusercontent.com/assets/1186124/10469550/1797043e-71d4-11e5-9287-9d3564532299.png)
