### PR TITLE
Dont print GITHUB_TOKEN in travis

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -4,9 +4,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-# print all lines of script as they are run
-set -o xtrace
-
 lein doc
 
 env GIT_DEPLOY_REPO=https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG.git GIT_DEPLOY_DIR=doc GIT_DEPLOY_EMAIL=_@_ ./deploy.sh --verbose


### PR DESCRIPTION
@lspector In order to secure your github token you should: 

1. Remove existing github token
2. Merge this PR (dont have to create new release for this)
3. Create new github token
4. Change github token on Travis to new token