### PR TITLE
Add EDN logging

### DIFF
--- a/src/clojush/pushgp/pushgp.clj
+++ b/src/clojush/pushgp/pushgp.clj
@@ -128,13 +128,17 @@
           :print-homology-data false ; If true, prints the homology statistics
           ;;
           ;;----------------------------------------
-          ;; Arguments related to printing JSON or CSV logs
+          ;; Arguments related to printing JSON, EDN, or CSV logs
           ;;----------------------------------------
           :print-csv-logs false ;; Prints a CSV log of the population each generation
+          :print-edn-logs false ;; Prints an EDN log of the run
           :print-json-logs false ;; Prints a JSON log of the population each generation
           :csv-log-filename "log.csv" ;; The file to print CSV log to
+          :edn-log-filename "log.edn" ;; The file to print EDN log to
           :json-log-filename "log.json" ;; The file to print JSON log to
           :csv-columns [:generation :location :total-error :push-program-size] ;; The columns to include in a printed CSV beyond the generation and individual. Options include: [:generation :location :parent-uuids :genetic-operators :push-program-size :plush-genome-size :push-program :plush-genome :total-error :test-case-errors]
+          :edn-keys [:uuid :parent-uuids :genetic-operators :program :genome :total-error :errors] ;; Keys from clojush.individual.individual that should be included.
+          :edn-additional-keys [:generation :location] ;; additional information to include in the edn-printout. Available options are [:generation :location :push-program-size :plush-genome-size].
           :log-fitnesses-for-all-cases false ;; If true, the CSV and JSON logs will include the fitnesses of each individual on every test case
           :json-log-program-strings false ;; If true, JSON logs will include program strings for each individual
           )))

--- a/src/clojush/pushgp/pushgp.clj
+++ b/src/clojush/pushgp/pushgp.clj
@@ -283,7 +283,7 @@ into @push-argmap first."
     (random/with-rng (random/make-mersennetwister-rng (:random-seed @push-argmap))
       ;; set globals from parameters
       (reset-globals)
-      (initial-report) ;; Print the inital report
+      (initial-report @push-argmap) ;; Print the inital report
       (print-params @push-argmap)
       (check-genetic-operator-probabilities-add-to-one @push-argmap)
       (timer @push-argmap :initialization)

--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -424,7 +424,7 @@
 
 (defn initial-report
   "Prints the initial report of a PushGP run."
-  []
+  [push-argmap]
   (println "Registered instructions:" @registered-instructions)
   (println "Starting PushGP run.")
   (printf "Clojush version = ")

--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -105,6 +105,25 @@
                                               (:errors individual))))
                           population)))))
 
+(defn edn-print
+  "Takes a population and appends all the individuals to the EDN log file.
+   If the internal representation of individuals changes in future versions
+   of Clojush, this code will likely continue to work, but will produce
+   output corresponding to the new representation."
+  [population generation edn-log-filename keys additional-keys]
+  (with-open [w (io/writer edn-log-filename :append true)] ;; Opens and closes the file once per call
+    (doall
+     (map-indexed (fn [index individual]
+            (let [additional-data {:generation generation
+                                   :location index
+                                   :push-program-size (count-points (:program individual))
+                                   :plush-genome-size (count (:genome individual))}]
+              (.write w "#clojush/individual")
+              (.write w (prn-str (merge
+                                  (select-keys additional-data additional-keys)
+                                  (select-keys individual keys))))))
+          population))))
+
 (defn jsonize-individual
   "Takes an individual and returns it with only the items of interest
    for the json logs."
@@ -251,6 +270,7 @@
            ;; The following are for CSV or JSON logs
            print-csv-logs print-json-logs csv-log-filename json-log-filename
            log-fitnesses-for-all-cases json-log-program-strings
+           print-edn-logs edn-keys edn-log-filename edn-additional-keys
            ]
     :as argmap}]
   (println)
@@ -416,6 +436,7 @@
     (when print-csv-logs (csv-print population generation argmap))
     (when print-json-logs (json-print population generation json-log-filename
                                       log-fitnesses-for-all-cases json-log-program-strings))
+    (when print-edn-logs (edn-print population generation edn-log-filename edn-keys edn-additional-keys))
     (cond (or (<= (:total-error best) error-threshold)
               (:success best)) [:success best]
           (>= generation max-generations) [:failure best]
@@ -457,7 +478,18 @@
     (catch Exception e
            (printf "Hash of last Git commit = unavailable\n")
            (printf "GitHub link = unavailable\n")
-           (flush))))
+           (flush)))
+  (if (:print-edn-logs push-argmap)
+    ;; The edn log is overwritten if it exists
+    (with-open [w (io/writer (:edn-log-filename push-argmap) :append false)]
+      (.write w "#clojush/run")
+      (.write w (prn-str (dissoc push-argmap
+                                 ;; These keys have functions
+                                 :atom-generators
+                                 :error-function
+                                 :problem-specific-report
+                                 :random-seed))))))
+
 
 (defn final-report
   "Prints the final report of a PushGP run if the run is successful."


### PR DESCRIPTION
For each individual the EDN logging allows printing of all the fields from an [individual](https://github.com/lspector/Clojush/blob/master/src/clojush/individual.clj#L8) as well as the additional fields provided by the CSV output. It also prints out the push-argmap except for the fields which contain functions since attempting to print them produces invalid EDN. The general form of the log is as follows:

```
#clojush/run { the argmap }  
#clojush/individual { map of an individual + the additional fields }
#clojush/individual {...}
...
```
At the moment, the only restriction on the ordering of the stream (in our code that parses this output) is that both an individual's parents occur before it.