### PR TITLE
Fix `breed` `NullPointerException` bug

### DIFF
--- a/src/clojush/pushgp/breed.clj
+++ b/src/clojush/pushgp/breed.clj
@@ -135,7 +135,8 @@
     (let [prob (lrand)]
       (loop [vectored-go-probabilities (reductions #(assoc %2 1 (+ (second %1) (second %2)))
                                                    (vec genetic-operator-probabilities))]
-        (if (<= prob (second (first vectored-go-probabilities)))
+        (if (or (= 1 (count vectored-go-probabilities))
+                (<= prob (second (first vectored-go-probabilities))))
           (perform-genetic-operator (first (first vectored-go-probabilities)) population location rand-gen argmap)
           (recur (rest vectored-go-probabilities)))))))
 


### PR DESCRIPTION
Fixes https://github.com/lspector/Clojush/issues/225

When going through the list of genetic operators, we now check when
there's just one operator left and choose that. This avoids the
rare but occassional situation where we'd get a `NullPointerException`
because we'd run through the whole list of operators without the sum
of the probabilities getting past the random number.