### PR TITLE
Added uniform-combination as a genetic operator

### DIFF
--- a/src/clojush/args.clj
+++ b/src/clojush/args.clj
@@ -151,11 +151,14 @@
 
           :uniform-addition-and-deletion-rate 0.01
           ;; The probability, per gene, for additions in the first phase, and deletions in the second
-          ;; phase, of uniform-addition-and-deletion.
+          ;; phase (calculated for size-neutrality), of uniform-addition-and-deletion.
+
+          :uniform-combination-rate 0.01
+          ;; The probability, per gene, for combinations during uniform-combination
 
           :uniform-combination-and-deletion-rate 0.01
           ;; The probability, per gene, for combinations in the first phase, and deletions in
-          ;; the second phase, of uniform-combination-and-deletion.
+          ;; the second phase (calculated for size-neutrality), of uniform-combination-and-deletion.
 
           :uniform-silence-mutation-rate 0.1
           ;; The probability of each :silent being switched during uniform silent mutation.

--- a/src/clojush/pushgp/breed.clj
+++ b/src/clojush/pushgp/breed.clj
@@ -23,6 +23,7 @@
    :uniform-deletion {:fn uniform-deletion :parents 1}
    :uniform-addition {:fn uniform-addition :parents 1}
    :uniform-addition-and-deletion {:fn uniform-addition-and-deletion :parents 1}
+   :uniform-combination {:fn uniform-combination :parents 2}
    :uniform-combination-and-deletion {:fn uniform-combination-and-deletion :parents 2}
    :genesis {:fn genesis :parents 1} ;; the parent will be ignored
    :make-next-operator-revertable {:fn nil :parents 0}


### PR DESCRIPTION
Also, I removed an unnecessary parameter from uniform-combination-and-deletion.

Question from while I was doing this: is there a reason that uniform-combination-and-deletion, and a bunch of the other uniform operators that @lspector added, use `mapv` to process the genes, and then immediately call another function on it, and then have to convert the result into a vector with `vec`? It seems like map would be just as good there, but maybe there's a reason I'm not considering. Example:

https://github.com/lspector/Clojush/blob/master/src/clojush/pushgp/genetic_operators.clj#L641