### PR TITLE
ALPS and Age changes

### DIFF
--- a/src/clojush/args.clj
+++ b/src/clojush/args.clj
@@ -516,7 +516,21 @@
           ;; Determines the proportion of cases to use when using downsampled lexicase.
           ;; When set to 1, has no effect. Should be in the range (0, 1].
 
-         
+         :use-ALPS false
+          ;; When true, will enable the Age-Layered Population Structure. This is available
+          ;; with any parent selection technique. With this implementation of ALPS, parents
+          ;; for children of a given layer can be selected from that layer or any layer below
+          ;; it. In other words, each layer has an age limit, and parents of individuals in
+          ;; each layer can be of any age below the age limit.
+
+         :ALPS-number-of-layers 10
+          ;; The number of layers for the population when using ALPS
+
+         :ALPS-age-limit-system :polynomial
+          ;; The age limiting system used for ALPS.
+          ;; Options: :polynomial, :linear, :exponential, :fibonacci
+          ;; :polynomial, the default, is what is used in the first ALPS paper
+
           ;;----------------------------------------
           ;; Arguments related to the Push interpreter
           ;;----------------------------------------

--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -291,7 +291,6 @@
         new-genome (mapv token-mutator (:genome ind))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -319,7 +318,6 @@
         new-genome (mapv token-mutator (:genome ind))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -357,7 +355,6 @@
         new-genome (mapv token-mutator (:genome ind))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -394,7 +391,6 @@
         new-genome (mapv token-mutator (:genome ind))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -434,7 +430,6 @@
         new-genome (mapv token-mutator (:genome ind))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -475,7 +470,6 @@
         new-genome (mapv token-mutator (:genome ind))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -503,7 +497,6 @@
         new-genome (mapv token-mutator (:genome ind))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -538,7 +531,6 @@
           new-genome (mapv close-mutator (:genome ind))]
       (make-individual :genome new-genome
                        :history (:history ind)
-                       :age (inc (:age ind))
                        :grain-size (compute-grain-size new-genome ind argmap)
                        :ancestors (if maintain-ancestors
                                     (cons (:genome ind) (:ancestors ind))
@@ -565,7 +557,6 @@
           new-genome (mapv silent-mutator (:genome ind))]
       (make-individual :genome new-genome
                        :history (:history ind)
-                       :age (inc (:age ind))
                        :grain-size (compute-grain-size new-genome ind argmap)
                        :ancestors (if maintain-ancestors
                                     (cons (:genome ind) (:ancestors ind))
@@ -585,7 +576,6 @@ given by uniform-deletion-rate.
                                       (:genome ind))))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -609,7 +599,6 @@ given by uniform-deletion-rate.
                                      (:genome ind))))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -642,7 +631,6 @@ given by uniform-deletion-rate.
                                       after-addition)))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -671,7 +659,6 @@ given by uniform-deletion-rate.
                                  (cycle (:genome parent2)))))]
     (make-individual :genome new-genome
                      :history (:history parent1)
-                     :age ((age-combining-function argmap) parent1 parent2 new-genome)
                      :grain-size (compute-grain-size new-genome parent1 parent2 argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome parent1) (:ancestors parent1))
@@ -707,7 +694,6 @@ given by uniform-deletion-rate.
                                       after-combination)))]
     (make-individual :genome new-genome
                      :history (:history parent1)
-                     :age ((age-combining-function argmap) parent1 parent2 new-genome)
                      :grain-size (compute-grain-size new-genome parent1 parent2 argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome parent1) (:ancestors parent1))
@@ -746,7 +732,6 @@ given by uniform-deletion-rate.
                                 (dec iteration-budget)))))]
     (make-individual :genome new-genome
                      :history (:history parent1)
-                     :age ((age-combining-function argmap) parent1 parent2 new-genome)
                      :grain-size (compute-grain-size new-genome parent1 parent2 argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome parent1) (:ancestors parent1))
@@ -772,7 +757,6 @@ given by uniform-deletion-rate.
                                       genome1)))]
     (make-individual :genome new-genome
                      :history (:history parent1)
-                     :age ((age-combining-function argmap) parent1 parent2 new-genome)
                      :grain-size (compute-grain-size new-genome parent1 parent2 argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome parent1) (:ancestors parent1))
@@ -808,7 +792,6 @@ given by uniform-deletion-rate.
                                   long-genome)))]
       (make-individual :genome new-genome
                        :history (:history parent1)
-                       :age ((age-combining-function argmap) parent1 parent2 new-genome)
                        :grain-size (compute-grain-size new-genome parent1 parent2 argmap)
                        :ancestors (if maintain-ancestors
                                     (cons (:genome parent1) (:ancestors parent1))
@@ -841,7 +824,6 @@ given by uniform-deletion-rate.
                                            (- (count parent-genome) (inc index))))))))]
     (make-individual :genome new-genome
                      :history (:history initial-parent)
-                     :age (inc (:age initial-parent))
                      :grain-size (compute-grain-size new-genome initial-parent argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome initial-parent) (:ancestors initial-parent))
@@ -865,7 +847,6 @@ given by uniform-deletion-rate.
         new-genome (vec (filter identity (apply concat reordered)))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -895,7 +876,6 @@ given by uniform-deletion-rate.
         new-genome (vec (apply concat (filter identity (apply concat reordered))))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -921,7 +901,6 @@ given by uniform-deletion-rate.
                                            segmented)))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -947,7 +926,6 @@ given by uniform-deletion-rate.
                                            segmented)))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))
@@ -973,7 +951,6 @@ given by uniform-deletion-rate.
                                            segmented)))]
     (make-individual :genome new-genome
                      :history (:history ind)
-                     :age (inc (:age ind))
                      :grain-size (compute-grain-size new-genome ind argmap)
                      :ancestors (if maintain-ancestors
                                   (cons (:genome ind) (:ancestors ind))

--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -164,7 +164,7 @@
                                              atom-generators
                                              argmap)
                  :plushy (random-plushy-genome
-                          (* 1.165
+                          (* plushy-max-genome-size-modifier
                              max-genome-size-in-initial-program)
                           atom-generators
                           argmap))]

--- a/src/clojush/pushgp/genetic_operators.clj
+++ b/src/clojush/pushgp/genetic_operators.clj
@@ -156,9 +156,8 @@
 (defn genesis
   "Ignores the provided parent and returns a new, random individual, with age 0.
   Works with Plushy genomes."
-  [ind {:keys [maintain-ancestors max-genome-size-in-initial-program atom-generators
-               genome-representation]
-        :as argmap}]
+  [{:keys [max-genome-size-in-initial-program atom-generators genome-representation]
+    :as argmap}]
   (let [genome (case genome-representation
                  :plush (random-plush-genome max-genome-size-in-initial-program
                                              atom-generators
@@ -171,10 +170,8 @@
     (make-individual :genome genome
                      :history ()
                      :age 0
-                     :grain-size (compute-grain-size genome argmap)
-                     :ancestors (if maintain-ancestors
-                                  (cons (:genome ind) (:ancestors ind))
-                                  (:ancestors ind)))))
+                     :genetic-operators :random
+                     :grain-size (compute-grain-size genome argmap))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; uniform mutation

--- a/src/clojush/pushgp/pushgp.clj
+++ b/src/clojush/pushgp/pushgp.clj
@@ -7,7 +7,7 @@
          simplification translate]
         [clojush.instructions boolean code common numbers random-instructions string char vectors
          tag zip environment input-output genome gtm]
-        [clojush.pushgp breed report]
+        [clojush.pushgp breed report genetic-operators]
         [clojush.pushgp.selection
          selection epsilon-lexicase elitegroup-lexicase implicit-fitness-sharing novelty eliteness
          fitness-proportionate downsampled-lexicase]
@@ -40,19 +40,7 @@
            max-genome-size-in-initial-program atom-generators genome-representation]
     :as argmap}]
   (let [population-agents (vec (repeatedly population-size
-                                           #(make-individual
-                                             :genome (case genome-representation
-                                                       :plush (strip-random-insertion-flags
-                                                               (random-plush-genome
-                                                                max-genome-size-in-initial-program
-                                                                atom-generators
-                                                                argmap))
-                                                       :plushy (random-plushy-genome
-                                                                (* plushy-max-genome-size-modifier
-                                                                   max-genome-size-in-initial-program)
-                                                                atom-generators
-                                                                argmap))
-                                             :genetic-operators :random)))]
+                                           #(genesis argmap)))]
     (mapv #(if use-single-thread
              (atom %)
              (agent % :error-handler agent-error-handler))

--- a/src/clojush/pushgp/pushgp.clj
+++ b/src/clojush/pushgp/pushgp.clj
@@ -48,7 +48,7 @@
                                                                 atom-generators
                                                                 argmap))
                                                        :plushy (random-plushy-genome
-                                                                (* 1.165
+                                                                (* plushy-max-genome-size-modifier
                                                                    max-genome-size-in-initial-program)
                                                                 atom-generators
                                                                 argmap))

--- a/src/clojush/pushgp/report.clj
+++ b/src/clojush/pushgp/report.clj
@@ -342,7 +342,7 @@
            print-errors print-history print-cosmos-data print-timings
            problem-specific-report total-error-method
            parent-selection print-homology-data max-point-evaluations
-           max-program-executions
+           max-program-executions use-ALPS
            print-error-frequencies-by-case normalization autoconstructive
            print-selection-counts print-preselection-fraction exit-on-success
            ;; The following are for CSV or JSON logs
@@ -456,6 +456,7 @@
             (r/generation-data! [:best :percent-parens]
               (double (/ (count-parens (:program best))
                          (count-points (:program best)))))) ;Number of (open) parens / points
+    (println "Age:" (:age best))
     (println "--- Population Statistics ---")
     (when print-cosmos-data
       (println "Cosmos Data:" (let [quants (config/quantiles (count population))]
@@ -491,6 +492,8 @@
           (r/generation-data! [:population-report :mean-program-percent-params]
             (mean (map #(double (/ (count-parens (:program %)) (count-points (:program %)))) sorted))))
     (let [ages (map :age population)]
+      (when use-ALPS
+        (println "Population ages:" ages))
       (println "Minimum age in population:"
           (r/generation-data! [:population-report :min-age]
                (* 1.0 (apply min ages))))

--- a/src/clojush/random.clj
+++ b/src/clojush/random.clj
@@ -97,6 +97,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; random plushy genome generator
 
+; This is the different in max sizes between plushy genomes and plush genomes, which is
+; used when creating random programs.
+(def plushy-max-genome-size-modifier 1.165)
+
 (defn random-plushy-instruction
   "Returns a random Plushy instruction. :close will appear more often than
   other instructions at a rate of :plushy-close-probability"


### PR DESCRIPTION
This pull request adds ALPS, which can be used with any parent selection method.

@lspector should take a careful look at the changes here, to make sure none of them break autoconstruction, which I did not test.

@NicMcPhee: This makes a few changes about the `:genetic-operators` key associated with randomly generated individuals. It's possible that this could break some of your assumptions about those tags in individuals, when tracking genealogies. Just wanted to mention this in case you use this code to generate genealogies in the future.