### PR TITLE
Fixes accidental change in max generations for the Last Index Of Zero…

### DIFF
--- a/src/clojush/problems/software/last_index_of_zero.clj
+++ b/src/clojush/problems/software/last_index_of_zero.clj
@@ -163,7 +163,7 @@
    :max-genome-size-in-initial-program 150
    :evalpush-limit 600
    :population-size 1000
-   :max-generations (/ 300 0.1)
+   :max-generations 300
    :parent-selection :lexicase
    :genetic-operator-probabilities {:alternation 0.2
                                     :uniform-mutation 0.2


### PR DESCRIPTION
… problem.

An earlier commit accidentally changed the max generations for Last Index of Zero to 3000. Anyone who has used this problem since then should check their results to see if they use 3000 generations.