### PR TITLE
Added checks for NaN and POSITIVE/NEGATIVE INFINITY in keep-number-re…

### DIFF
--- a/src/clojush/util.clj
+++ b/src/clojush/util.clj
@@ -81,6 +81,9 @@
       :else n)
     :else
     (cond
+      (Double/isNaN n) 0.0
+      (= n Double/POSITIVE_INFINITY) (* 1.0 max-number-magnitude)
+      (= n Double/NEGATIVE_INFINITY) (* 1.0 (- max-number-magnitude))
       (> n max-number-magnitude) (* 1.0 max-number-magnitude)
       (< n (- max-number-magnitude)) (* 1.0 (- max-number-magnitude))
       (and (< n min-number-magnitude) (> n (- min-number-magnitude))) 0.0


### PR DESCRIPTION
…asonable.

I believe this should take care of rare occurrences where mod on doubles or parsing of strings to float causes NaN or Inf to appear on the float stack.