### PR TITLE
fixed random plushy instruction

### DIFF
--- a/src/clojush/random.clj
+++ b/src/clojush/random.clj
@@ -1,5 +1,6 @@
 (ns clojush.random
-  (:use [clojush globals translate pushstate])
+  (:use [clojush globals translate pushstate]
+        clojush.instructions.common)
   (:require [clj-random.core :as random]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -109,7 +110,7 @@
                       plushy-close-probability
                       (/ (apply + (filter identity ; This will look up each atom generator in the instruction table and
                                                    ; get the number of parentheses it requires
-                                          (map (comp :parentheses meta @instruction-table)
+                                          (map lookup-instruction-paren-groups
                                                atom-generators)))
                          (count atom-generators)))]
     (if (< (lrand) plushy-prob)


### PR DESCRIPTION
random-plushy-instruction() was not counting the code blocks opened by tagging instruction. Fixed that.